### PR TITLE
Add in-CLI Claude Code marketplace install for agent-wallet

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "agentlayer",
+  "description": "AgentLayer plugins for Claude Code. Install the wallet bridge and its backend runtime without leaving the CLI.",
+  "owner": {
+    "name": "AgentLayer",
+    "url": "https://github.com/lopushok9/Agent-Layer"
+  },
+  "plugins": [
+    {
+      "name": "agent-wallet",
+      "displayName": "Agent Wallet",
+      "description": "Bridge to the local AgentLayer wallet runtime (Solana, Bitcoin, EVM). Installs and connects the backend runtime on first use.",
+      "category": "development",
+      "source": "./claude-code/plugins/agent-wallet"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -25,16 +25,31 @@ npx @agentlayer.tech/wallet install --yes && npx @agentlayer.tech/wallet claude-
 ```
 
 Or install entirely from inside the Claude Code CLI, via the plugin marketplace
-(no terminal/npx needed):
+(no terminal/npx needed) — two commands, then restart:
 
 ```text
 /plugin marketplace add lopushok9/Agent-Layer
 /plugin install agent-wallet@agentlayer
-/wallet-setup
 ```
 
-`/wallet-setup` bridges to the npm installer to lay down the backend runtime;
-after it finishes, restart Claude Code to activate the wallet tools.
+Restart Claude Code (or run `/reload-plugins`). On the next session start the
+plugin auto-installs its backend runtime via a `SessionStart` hook — the same
+`install --yes` that configures the wallet out of the box. No third command
+needed. (If you prefer to trigger it by hand, run `/wallet-setup`; opt out of the
+auto-install with `AGENT_WALLET_NO_AUTO_BOOTSTRAP=1`.)
+
+To get team members down to effectively zero typed commands, pre-register the
+marketplace in `.claude/settings.json` so Claude Code prompts to install on
+trust:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "agentlayer": { "source": { "source": "github", "repo": "lopushok9/Agent-Layer" } }
+  },
+  "enabledPlugins": { "agent-wallet@agentlayer": true }
+}
+```
 
 For Hermes:
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ Or install entirely from inside the Claude Code CLI, via the plugin marketplace
 /plugin install agent-wallet@agentlayer
 ```
 
-Restart Claude Code (or run `/reload-plugins`). On the next session start the
-plugin auto-installs its backend runtime via a `SessionStart` hook — the same
-`install --yes` that configures the wallet out of the box. No third command
-needed. (If you prefer to trigger it by hand, run `/wallet-setup`; opt out of the
-auto-install with `AGENT_WALLET_NO_AUTO_BOOTSTRAP=1`.)
+Restart Claude Code (or run `/reload-plugins`), then run `/wallet-setup` to
+install the backend runtime — a bridge to the same `install --yes` that
+configures the wallet out of the box. On session start a `SessionStart` hook
+checks whether the backend is present and reminds you to run `/wallet-setup` if
+it is missing. To skip the prompt and have the hook install the backend
+automatically on session start instead, set `AGENT_WALLET_AUTO_BOOTSTRAP=1`.
 
 To get team members down to effectively zero typed commands, pre-register the
 marketplace in `.claude/settings.json` so Claude Code prompts to install on

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ For Claude Code:
 npx @agentlayer.tech/wallet install --yes && npx @agentlayer.tech/wallet claude-code install --yes
 ```
 
+Or install entirely from inside the Claude Code CLI, via the plugin marketplace
+(no terminal/npx needed):
+
+```text
+/plugin marketplace add lopushok9/Agent-Layer
+/plugin install agent-wallet@agentlayer
+/wallet-setup
+```
+
+`/wallet-setup` bridges to the npm installer to lay down the backend runtime;
+after it finishes, restart Claude Code to activate the wallet tools.
+
 For Hermes:
 
 ```bash

--- a/claude-code/plugins/agent-wallet/README.md
+++ b/claude-code/plugins/agent-wallet/README.md
@@ -40,18 +40,22 @@ and its backend runtime — without leaving the CLI. Two commands, then restart:
 /plugin install agent-wallet@agentlayer
 ```
 
-Restart Claude Code (or `/reload-plugins`). On the next session start a
-`SessionStart` hook auto-runs `scripts/bootstrap_backend.sh`, a thin bridge to
-the npm installer (`npx @agentlayer.tech/wallet install --yes`). The marketplace
-only copies this MCP bridge into Claude Code's cache; the bootstrap step lays
-down the Python backend runtime (venv + `agent_wallet` + `server.py`) that the
-bridge talks to, with the wallet configured out of the box. It is idempotent and
-a no-op once the backend is healthy.
+Restart Claude Code (or `/reload-plugins`), then run `/wallet-setup`. It runs
+`scripts/bootstrap_backend.sh`, a thin bridge to the npm installer
+(`npx @agentlayer.tech/wallet install --yes`). The marketplace only copies this
+MCP bridge into Claude Code's cache; the bootstrap step lays down the Python
+backend runtime (venv + `agent_wallet` + `server.py`) that the bridge talks to,
+with the wallet configured out of the box. It is idempotent and a no-op once the
+backend is healthy.
 
-- `/wallet-setup` — trigger the bootstrap by hand instead of waiting for a
-  restart (requires `/reload-plugins` first so the command is registered).
-- `AGENT_WALLET_NO_AUTO_BOOTSTRAP=1` — opt out of the auto-install; the hook then
-  only reminds you to run `/wallet-setup`.
+On session start a `SessionStart` hook runs `bootstrap_backend.sh check` and, if
+the backend is missing, reminds you to run `/wallet-setup` — it does not install
+anything by default.
+
+- `/wallet-setup` — install (or repair) the backend explicitly (requires
+  `/reload-plugins` first so the command is registered).
+- `AGENT_WALLET_AUTO_BOOTSTRAP=1` — opt in to auto-install: the `SessionStart`
+  hook then runs the bootstrap install itself instead of only reminding you.
 
 For near-zero typed commands, pre-register the marketplace in
 `.claude/settings.json` with `extraKnownMarketplaces` + `enabledPlugins` so

--- a/claude-code/plugins/agent-wallet/README.md
+++ b/claude-code/plugins/agent-wallet/README.md
@@ -30,7 +30,28 @@ Primary design rules:
 
 ## Installation
 
-### Automated (recommended)
+### From inside Claude Code (no terminal needed)
+
+The plugin ships in a git marketplace at the repo root, so you can install it —
+and its backend runtime — without leaving the CLI:
+
+```text
+/plugin marketplace add lopushok9/Agent-Layer
+/plugin install agent-wallet@agentlayer
+/wallet-setup
+```
+
+`/wallet-setup` runs `scripts/bootstrap_backend.sh`, a thin bridge to the npm
+installer (`npx @agentlayer.tech/wallet install --yes`). The marketplace only
+copies this MCP bridge into Claude Code's cache; the bootstrap step lays down the
+Python backend runtime (venv + `agent_wallet` + `server.py`) that the bridge
+talks to. It is idempotent and a no-op once the backend is healthy.
+
+A soft `SessionStart` hook reminds you to run `/wallet-setup` if the backend is
+missing. To auto-install the backend on session start instead of just being
+reminded, opt in with `AGENT_WALLET_AUTO_BOOTSTRAP=1`.
+
+### Automated via npm
 
 ```bash
 npx @agentlayer.tech/wallet install --yes

--- a/claude-code/plugins/agent-wallet/README.md
+++ b/claude-code/plugins/agent-wallet/README.md
@@ -33,23 +33,29 @@ Primary design rules:
 ### From inside Claude Code (no terminal needed)
 
 The plugin ships in a git marketplace at the repo root, so you can install it —
-and its backend runtime — without leaving the CLI:
+and its backend runtime — without leaving the CLI. Two commands, then restart:
 
 ```text
 /plugin marketplace add lopushok9/Agent-Layer
 /plugin install agent-wallet@agentlayer
-/wallet-setup
 ```
 
-`/wallet-setup` runs `scripts/bootstrap_backend.sh`, a thin bridge to the npm
-installer (`npx @agentlayer.tech/wallet install --yes`). The marketplace only
-copies this MCP bridge into Claude Code's cache; the bootstrap step lays down the
-Python backend runtime (venv + `agent_wallet` + `server.py`) that the bridge
-talks to. It is idempotent and a no-op once the backend is healthy.
+Restart Claude Code (or `/reload-plugins`). On the next session start a
+`SessionStart` hook auto-runs `scripts/bootstrap_backend.sh`, a thin bridge to
+the npm installer (`npx @agentlayer.tech/wallet install --yes`). The marketplace
+only copies this MCP bridge into Claude Code's cache; the bootstrap step lays
+down the Python backend runtime (venv + `agent_wallet` + `server.py`) that the
+bridge talks to, with the wallet configured out of the box. It is idempotent and
+a no-op once the backend is healthy.
 
-A soft `SessionStart` hook reminds you to run `/wallet-setup` if the backend is
-missing. To auto-install the backend on session start instead of just being
-reminded, opt in with `AGENT_WALLET_AUTO_BOOTSTRAP=1`.
+- `/wallet-setup` — trigger the bootstrap by hand instead of waiting for a
+  restart (requires `/reload-plugins` first so the command is registered).
+- `AGENT_WALLET_NO_AUTO_BOOTSTRAP=1` — opt out of the auto-install; the hook then
+  only reminds you to run `/wallet-setup`.
+
+For near-zero typed commands, pre-register the marketplace in
+`.claude/settings.json` with `extraKnownMarketplaces` + `enabledPlugins` so
+Claude Code prompts to install on trust.
 
 ### Automated via npm
 

--- a/claude-code/plugins/agent-wallet/commands/wallet-setup.md
+++ b/claude-code/plugins/agent-wallet/commands/wallet-setup.md
@@ -1,0 +1,24 @@
+---
+description: Install or repair the AgentLayer wallet backend runtime without leaving Claude Code.
+allowed-tools: Bash(sh:*), Bash(npx:*)
+---
+
+Install (or repair) the AgentLayer wallet backend that this plugin bridges to.
+
+Run the bootstrap bridge to the npm installer:
+
+```
+sh "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh" install
+```
+
+Then report the outcome to the user:
+
+- If it succeeded, tell them the backend is installed and that they should
+  restart Claude Code (or reload the `agent-wallet` plugin) so the wallet tools
+  become available.
+- If it failed because Node.js or Python is missing, relay the exact requirement
+  (Node.js 18+, Python >= 3.10 with venv) and the manual fallback command from
+  the script output.
+
+Do not pass or generate any secrets. The npm installer manages the local wallet
+keys and sealed secrets under `OPENCLAW_HOME` on its own.

--- a/claude-code/plugins/agent-wallet/hooks/hooks.json
+++ b/claude-code/plugins/agent-wallet/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "timeout": 600,
-            "command": "sh -c 'if [ \"${AGENT_WALLET_NO_AUTO_BOOTSTRAP:-0}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed. Run /wallet-setup to install it.\"; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; fi'"
+            "timeout": 300,
+            "command": "sh -c 'if [ \"${AGENT_WALLET_AUTO_BOOTSTRAP:-0}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed. Run /wallet-setup to install it.\"; fi'"
           }
         ]
       }

--- a/claude-code/plugins/agent-wallet/hooks/hooks.json
+++ b/claude-code/plugins/agent-wallet/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 600,
+            "command": "sh -c 'if [ \"${AGENT_WALLET_AUTO_BOOTSTRAP:-0}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed yet. Run /wallet-setup to install it without leaving Claude Code.\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-code/plugins/agent-wallet/hooks/hooks.json
+++ b/claude-code/plugins/agent-wallet/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "timeout": 600,
-            "command": "sh -c 'if [ \"${AGENT_WALLET_AUTO_BOOTSTRAP:-0}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed yet. Run /wallet-setup to install it without leaving Claude Code.\"; fi'"
+            "command": "sh -c 'if [ \"${AGENT_WALLET_NO_AUTO_BOOTSTRAP:-0}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed. Run /wallet-setup to install it.\"; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; fi'"
           }
         ]
       }

--- a/claude-code/plugins/agent-wallet/scripts/bootstrap_backend.sh
+++ b/claude-code/plugins/agent-wallet/scripts/bootstrap_backend.sh
@@ -27,10 +27,32 @@ MODE=${1:-install}
 PACKAGE_SPEC=${AGENT_WALLET_BOOTSTRAP_PACKAGE:-"@agentlayer.tech/wallet@latest"}
 OPENCLAW_HOME=${OPENCLAW_HOME:-"$HOME/.openclaw"}
 RUNTIME_CURRENT="$OPENCLAW_HOME/agent-wallet-runtime/current"
-SERVER_PY="$RUNTIME_CURRENT/codex/plugins/agent-wallet/server.py"
+
+# Resolve this script's plugin root with physical paths (pwd -P), the same way
+# run_mcp.sh does, so a marketplace symlink does not break the "../../../codex"
+# sibling math below.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+PLUGIN_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd -P)
 
 log() {
   printf '%s\n' "$*" >&2
+}
+
+# Locate server.py exactly like run_mcp.sh: the plugin's own copy, then the codex
+# sibling in a repo checkout, then the installed runtime package. Keeping this in
+# lock-step with run_mcp.sh is what avoids a false "not installed" verdict in a
+# dev checkout, where run_mcp.sh resolves the codex sibling but this script used
+# to look only at the runtime path.
+resolve_server() {
+  if [ -f "$PLUGIN_ROOT/server.py" ]; then
+    printf '%s' "$PLUGIN_ROOT/server.py"
+  elif [ -f "$PLUGIN_ROOT/../../../codex/plugins/agent-wallet/server.py" ]; then
+    printf '%s' "$PLUGIN_ROOT/../../../codex/plugins/agent-wallet/server.py"
+  elif [ -f "$RUNTIME_CURRENT/codex/plugins/agent-wallet/server.py" ]; then
+    printf '%s' "$RUNTIME_CURRENT/codex/plugins/agent-wallet/server.py"
+  else
+    printf '%s' ''
+  fi
 }
 
 resolve_python() {
@@ -47,17 +69,23 @@ resolve_python() {
   fi
 }
 
-# Healthy == the runtime server.py exists and parses. Parsing (ast.parse, no
-# bytecode written) is the same readiness proxy run_mcp.sh and `doctor` use.
+# Readiness proxy: the resolved server.py exists and parses (ast.parse, no
+# bytecode written) — the same shallow check run_mcp.sh and `doctor` run before
+# exec. It deliberately does NOT verify that the venv/dependencies are installed:
+# importing or running the server would be too slow and flaky for a SessionStart
+# hook and risks false-negative reinstall loops. run_mcp.sh surfaces any missing
+# dependency with a clear error at first tool use, so this stays in lock-step
+# with what actually runs the server rather than being stricter than it.
 backend_ready() {
-  [ -f "$SERVER_PY" ] || return 1
+  server=$(resolve_server)
+  [ -n "$server" ] || return 1
   py=$(resolve_python)
   [ -n "$py" ] || return 1
-  "$py" -c 'import sys, ast; ast.parse(open(sys.argv[1], encoding="utf-8").read())' "$SERVER_PY" 2>/dev/null
+  "$py" -c 'import sys, ast; ast.parse(open(sys.argv[1], encoding="utf-8").read())' "$server" 2>/dev/null
 }
 
 if backend_ready; then
-  [ "$MODE" = "check" ] || log "AgentLayer wallet backend already installed at $RUNTIME_CURRENT."
+  [ "$MODE" = "check" ] || log "AgentLayer wallet backend already installed (server: $(resolve_server))."
   exit 0
 fi
 

--- a/claude-code/plugins/agent-wallet/scripts/bootstrap_backend.sh
+++ b/claude-code/plugins/agent-wallet/scripts/bootstrap_backend.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -eu
+
+# bootstrap_backend.sh — the in-CLI bridge to the npm installer.
+#
+# Claude Code's plugin marketplace only copies the plugin files (this MCP bridge
+# and its skill) into the cache. It does NOT lay down the Python backend runtime
+# (venv + agent_wallet package + server.py + sealed-secret handling) that the
+# bridge talks to. This script closes that gap: it detects whether the backend
+# runtime is present and, if not, delegates to the existing npm installer
+# (`npx @agentlayer.tech/wallet install --yes`) so the whole thing can be set up
+# without leaving the Claude Code CLI.
+#
+# Modes:
+#   bootstrap_backend.sh check     Report readiness only. Exit 0 if ready, 1 if not.
+#                                  Never installs anything.
+#   bootstrap_backend.sh install   Ensure the backend is installed (default).
+#                                  Idempotent: a no-op when already healthy.
+#
+# Used by:
+#   - /wallet-setup slash command  -> `install` (explicit, user-initiated).
+#   - SessionStart hook            -> `check` (soft hint), or `install` when the
+#                                     user opts in with AGENT_WALLET_AUTO_BOOTSTRAP=1.
+
+MODE=${1:-install}
+
+PACKAGE_SPEC=${AGENT_WALLET_BOOTSTRAP_PACKAGE:-"@agentlayer.tech/wallet@latest"}
+OPENCLAW_HOME=${OPENCLAW_HOME:-"$HOME/.openclaw"}
+RUNTIME_CURRENT="$OPENCLAW_HOME/agent-wallet-runtime/current"
+SERVER_PY="$RUNTIME_CURRENT/codex/plugins/agent-wallet/server.py"
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+resolve_python() {
+  if [ -n "${AGENT_WALLET_PYTHON:-}" ]; then
+    printf '%s' "$AGENT_WALLET_PYTHON"
+  elif [ -x "$RUNTIME_CURRENT/agent-wallet/.venv/bin/python" ]; then
+    printf '%s' "$RUNTIME_CURRENT/agent-wallet/.venv/bin/python"
+  elif [ -x "$RUNTIME_CURRENT/agent-wallet/.runtime-venv/bin/python" ]; then
+    printf '%s' "$RUNTIME_CURRENT/agent-wallet/.runtime-venv/bin/python"
+  elif command -v python3 >/dev/null 2>&1; then
+    printf '%s' python3
+  else
+    printf '%s' ''
+  fi
+}
+
+# Healthy == the runtime server.py exists and parses. Parsing (ast.parse, no
+# bytecode written) is the same readiness proxy run_mcp.sh and `doctor` use.
+backend_ready() {
+  [ -f "$SERVER_PY" ] || return 1
+  py=$(resolve_python)
+  [ -n "$py" ] || return 1
+  "$py" -c 'import sys, ast; ast.parse(open(sys.argv[1], encoding="utf-8").read())' "$SERVER_PY" 2>/dev/null
+}
+
+if backend_ready; then
+  [ "$MODE" = "check" ] || log "AgentLayer wallet backend already installed at $RUNTIME_CURRENT."
+  exit 0
+fi
+
+if [ "$MODE" = "check" ]; then
+  log "AgentLayer wallet backend is not installed yet."
+  log "Run /wallet-setup inside Claude Code to install it."
+  exit 1
+fi
+
+# --- install path -----------------------------------------------------------
+
+if ! command -v npx >/dev/null 2>&1; then
+  log "Cannot install the AgentLayer wallet backend: npx (Node.js) was not found on PATH."
+  log "Install Node.js 18+ and re-run /wallet-setup, or run manually:"
+  log "  npx $PACKAGE_SPEC install --yes"
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  log "Warning: python3 was not found on PATH. The installer needs Python >= 3.10 with venv."
+  log "Install Python and re-run /wallet-setup if the install below fails."
+fi
+
+log "Installing the AgentLayer wallet backend runtime via npm (this may take a minute)…"
+log "  -> npx $PACKAGE_SPEC install --yes"
+if ! npx -y "$PACKAGE_SPEC" install --yes; then
+  log "Backend install failed. Ensure Node.js 18+ and Python >= 3.10 (with venv) are installed, then re-run /wallet-setup."
+  exit 1
+fi
+
+# Re-pin the Claude Code cache copies so run_mcp.sh resolves OPENCLAW_HOME and the
+# freshly installed runtime correctly (pinClaudeCacheCopies / marketplace wiring).
+# --skip-enable: the plugin is already registered via the marketplace, so we only
+# want the file pinning, not another `claude plugin install`.
+log "Wiring the Claude Code bridge to the installed runtime…"
+npx -y "$PACKAGE_SPEC" claude-code install --yes --skip-enable || \
+  log "Note: could not re-pin the Claude Code bridge automatically; it will still resolve the default runtime."
+
+if backend_ready; then
+  log "Done. The AgentLayer wallet backend is installed."
+  log "Restart Claude Code (or reload the agent-wallet plugin) to activate the wallet tools."
+  exit 0
+fi
+
+log "Install completed but the backend did not verify. Run: npx $PACKAGE_SPEC doctor --deep"
+exit 1

--- a/claude-code/plugins/agent-wallet/scripts/run_mcp.sh
+++ b/claude-code/plugins/agent-wallet/scripts/run_mcp.sh
@@ -27,7 +27,7 @@ elif [ -f "$CODEX_SERVER" ]; then
 elif [ -f "$RUNTIME_CODEX_DIR/server.py" ]; then
   SERVER_PY=$(CDPATH= cd -- "$RUNTIME_CODEX_DIR" && pwd -P)/server.py
 else
-  printf '{"error":"agent-wallet server.py not found in plugin, codex sibling, or runtime package.","fix":"npx @agentlayer.tech/wallet install --yes"}\n' >&2
+  printf '{"error":"agent-wallet backend not installed yet (server.py not found in plugin, codex sibling, or runtime package).","fix":"Run /wallet-setup inside Claude Code, or: npx @agentlayer.tech/wallet install --yes"}\n' >&2
   exit 1
 fi
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "agent-wallet/pyproject.toml",
     ".openclaw/AGENTS.md",
     ".openclaw/extensions/agent-wallet/",
+    ".claude-plugin/marketplace.json",
     "codex/plugins/agent-wallet/",
     "claude-code/plugins/agent-wallet/",
     "hermes/plugins/agent_wallet/",


### PR DESCRIPTION
Make the agent-wallet plugin installable entirely from inside the Claude
Code CLI via the plugin marketplace, with a bridge layer to the existing
npm installer for the backend runtime.

- .claude-plugin/marketplace.json: root git marketplace so users can run
  `/plugin marketplace add lopushok9/Agent-Layer` and
  `/plugin install agent-wallet@agentlayer` without leaving the CLI.
- scripts/bootstrap_backend.sh: idempotent bridge to the npm installer
  (`npx @agentlayer.tech/wallet install --yes`) that lays down the Python
  backend runtime the marketplace copy cannot ship, then re-pins the
  Claude Code cache wiring.
- commands/wallet-setup.md: `/wallet-setup` to run the bootstrap explicitly.
- hooks/hooks.json: soft SessionStart hook that hints to run /wallet-setup
  when the backend is missing (auto-install opt-in via
  AGENT_WALLET_AUTO_BOOTSTRAP=1).
- run_mcp.sh: clearer not-installed message pointing at /wallet-setup.
- package.json files + README/plugin README updated for the in-CLI flow.