### PR TITLE
Auto-install wallet backend on session start by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Or install entirely from inside the Claude Code CLI, via the plugin marketplace
 /plugin install agent-wallet@agentlayer
 ```
 
-Restart Claude Code (or run `/reload-plugins`), then run `/wallet-setup` to
-install the backend runtime — a bridge to the same `install --yes` that
-configures the wallet out of the box. On session start a `SessionStart` hook
-checks whether the backend is present and reminds you to run `/wallet-setup` if
-it is missing. To skip the prompt and have the hook install the backend
-automatically on session start instead, set `AGENT_WALLET_AUTO_BOOTSTRAP=1`.
+Restart Claude Code (or run `/reload-plugins`). On the next session start a
+`SessionStart` hook installs the backend runtime automatically — a bridge to the
+same `install --yes` that configures the wallet out of the box. No third command
+needed. (Prefer to trigger it by hand instead? Run `/wallet-setup`. Opt out of
+the auto-install with `AGENT_WALLET_AUTO_BOOTSTRAP=0` — the hook then only
+reminds you to run `/wallet-setup`.)
 
 To get team members down to effectively zero typed commands, pre-register the
 marketplace in `.claude/settings.json` so Claude Code prompts to install on

--- a/claude-code/plugins/agent-wallet/README.md
+++ b/claude-code/plugins/agent-wallet/README.md
@@ -40,22 +40,20 @@ and its backend runtime — without leaving the CLI. Two commands, then restart:
 /plugin install agent-wallet@agentlayer
 ```
 
-Restart Claude Code (or `/reload-plugins`), then run `/wallet-setup`. It runs
-`scripts/bootstrap_backend.sh`, a thin bridge to the npm installer
-(`npx @agentlayer.tech/wallet install --yes`). The marketplace only copies this
-MCP bridge into Claude Code's cache; the bootstrap step lays down the Python
-backend runtime (venv + `agent_wallet` + `server.py`) that the bridge talks to,
-with the wallet configured out of the box. It is idempotent and a no-op once the
-backend is healthy.
+Restart Claude Code (or `/reload-plugins`). On the next session start a
+`SessionStart` hook runs `scripts/bootstrap_backend.sh`, a thin bridge to the
+npm installer (`npx @agentlayer.tech/wallet install --yes`). The marketplace only
+copies this MCP bridge into Claude Code's cache; the bootstrap step lays down the
+Python backend runtime (venv + `agent_wallet` + `server.py`) that the bridge
+talks to, with the wallet configured out of the box. It is idempotent and a
+no-op once the backend is healthy.
 
-On session start a `SessionStart` hook runs `bootstrap_backend.sh check` and, if
-the backend is missing, reminds you to run `/wallet-setup` — it does not install
-anything by default.
-
-- `/wallet-setup` — install (or repair) the backend explicitly (requires
-  `/reload-plugins` first so the command is registered).
-- `AGENT_WALLET_AUTO_BOOTSTRAP=1` — opt in to auto-install: the `SessionStart`
-  hook then runs the bootstrap install itself instead of only reminding you.
+- `/wallet-setup` — install (or repair) the backend explicitly instead of
+  waiting for the hook (requires `/reload-plugins` first so the command is
+  registered).
+- `AGENT_WALLET_AUTO_BOOTSTRAP=0` — opt out of the auto-install: the
+  `SessionStart` hook then only reminds you to run `/wallet-setup` instead of
+  installing the backend itself.
 
 For near-zero typed commands, pre-register the marketplace in
 `.claude/settings.json` with `extraKnownMarketplaces` + `enabledPlugins` so

--- a/claude-code/plugins/agent-wallet/hooks/hooks.json
+++ b/claude-code/plugins/agent-wallet/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "timeout": 300,
-            "command": "sh -c 'if [ \"${AGENT_WALLET_AUTO_BOOTSTRAP:-0}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed. Run /wallet-setup to install it.\"; fi'"
+            "command": "sh -c 'if [ \"${AGENT_WALLET_AUTO_BOOTSTRAP:-1}\" = \"1\" ]; then \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" install >&2; else \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap_backend.sh\" check >/dev/null 2>&1 || echo \"AgentLayer wallet backend is not installed. Run /wallet-setup to install it.\"; fi'"
           }
         ]
       }

--- a/claude-code/plugins/agent-wallet/scripts/bootstrap_backend.sh
+++ b/claude-code/plugins/agent-wallet/scripts/bootstrap_backend.sh
@@ -19,8 +19,10 @@ set -eu
 #
 # Used by:
 #   - /wallet-setup slash command  -> `install` (explicit, user-initiated).
-#   - SessionStart hook            -> `check` (soft hint), or `install` when the
-#                                     user opts in with AGENT_WALLET_AUTO_BOOTSTRAP=1.
+#   - SessionStart hook            -> `install` by default, so the backend sets
+#                                     itself up on first session. Set
+#                                     AGENT_WALLET_AUTO_BOOTSTRAP=0 to opt out and
+#                                     get only a soft hint to run /wallet-setup.
 
 MODE=${1:-install}
 


### PR DESCRIPTION
Makes the SessionStart hook default to installing the backend runtime, so a fresh `/plugin install agent-wallet@agentlayer` sets itself up on first session with no extra command.

- `AGENT_WALLET_AUTO_BOOTSTRAP` default flips `0` -> `1`.
- Opt out with `AGENT_WALLET_AUTO_BOOTSTRAP=0` (hook then only hints `/wallet-setup`).
- Docs + script comment updated.

Verified hook branch selection (unset/=1 -> install, =0 -> hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)