### PR TITLE
fix: exclude failing DEXes on swap simulation retry for Token-2022 tokens

### DIFF
--- a/agent-wallet/agent_wallet/providers/jupiter.py
+++ b/agent-wallet/agent_wallet/providers/jupiter.py
@@ -117,6 +117,7 @@ async def fetch_quote(
     restrict_intermediate_tokens: bool = True,
     only_direct_routes: bool = False,
     swap_mode: str = "ExactIn",
+    exclude_dexes: list[str] | None = None,
 ) -> dict[str, Any]:
     """Fetch a Jupiter quote for an exact-in swap.
 
@@ -133,6 +134,7 @@ async def fetch_quote(
             restrict_intermediate_tokens=restrict_intermediate_tokens,
             only_direct_routes=only_direct_routes,
             swap_mode=swap_mode,
+            exclude_dexes=exclude_dexes,
         )
     except ProviderError as exc:
         error_msg = str(exc).lower()
@@ -168,6 +170,7 @@ async def _fetch_quote_direct(
     restrict_intermediate_tokens: bool = True,
     only_direct_routes: bool = False,
     swap_mode: str = "ExactIn",
+    exclude_dexes: list[str] | None = None,
 ) -> dict[str, Any]:
     """Fetch a Jupiter quote directly from Jupiter API."""
     client = get_client()
@@ -180,6 +183,8 @@ async def _fetch_quote_direct(
         "restrictIntermediateTokens": str(restrict_intermediate_tokens).lower(),
         "onlyDirectRoutes": str(only_direct_routes).lower(),
     }
+    if exclude_dexes:
+        params["excludeDexes"] = ",".join(str(d).strip() for d in exclude_dexes if str(d).strip())
     response = await client.get(
         f"{settings.jupiter_api_base_url.rstrip('/')}/quote",
         params=params,

--- a/agent-wallet/agent_wallet/wallet_layer/solana.py
+++ b/agent-wallet/agent_wallet/wallet_layer/solana.py
@@ -4704,6 +4704,7 @@ class SolanaWalletBackend(AgentWalletBackend):
         amount_ui: float,
         slippage_bps: int = SOLANA_SWAP_DEFAULT_SLIPPAGE_BPS,
         exclude_routers: list[str] | None = None,
+        exclude_dexes: list[str] | None = None,
     ) -> dict[str, Any]:
         if self.network != "mainnet":
             raise WalletBackendError("Provider-routed swaps are only enabled for Solana mainnet.")
@@ -4749,6 +4750,7 @@ class SolanaWalletBackend(AgentWalletBackend):
                     output_mint=output_mint,
                     amount_raw=raw_amount,
                     slippage_bps=slippage_bps,
+                    exclude_dexes=exclude_dexes,
                 )
                 quote_source = "jupiter-metis"
 
@@ -5006,17 +5008,27 @@ class SolanaWalletBackend(AgentWalletBackend):
 
         attempts: list[dict[str, Any]] = []
         last_error: str | None = None
+        _simulation_failed = False
         for attempt_index in range(max_attempts):
             if valid_until_epoch_seconds is not None and int(time.time()) > int(valid_until_epoch_seconds):
                 break
             try:
                 exclude_routers = ["jupiterz"] if attempt_index > 0 else None
+                # On retries after a simulation failure, exclude DEXes known to fail
+                # simulation for Token-2022 tokens with extensions such as
+                # scaledUiAmountConfig, pausableConfig, or permanentDelegate
+                # (e.g. Backpack xStock tokens). GoonFi V2 is the primary offender;
+                # ZeroFi handles these tokens correctly.
+                exclude_dexes: list[str] | None = None
+                if _simulation_failed and attempt_index > 0:
+                    exclude_dexes = ["GoonFi V2"]
                 preview = await self.preview_swap(
                     input_mint=input_mint,
                     output_mint=output_mint,
                     amount_ui=amount_ui,
                     slippage_bps=slippage_bps,
                     exclude_routers=exclude_routers,
+                    exclude_dexes=exclude_dexes,
                 )
                 estimated_output_raw = int(preview.get("estimated_output_amount_raw") or 0)
                 if (
@@ -5073,6 +5085,8 @@ class SolanaWalletBackend(AgentWalletBackend):
                 return result
             except (WalletBackendError, ProviderError) as exc:
                 last_error = str(exc)
+                if "simulation failed" in str(exc).lower():
+                    _simulation_failed = True
                 attempts.append(
                     {
                         "attempt": attempt_index + 1,


### PR DESCRIPTION
## Problem

Swapping Token-2022 tokens with complex extensions (e.g. Backpack xStock tokens like SPCX — which have `scaledUiAmountConfig`, `pausableConfig`, `permanentDelegate`, and `confidentialTransferMint`) consistently failed with:

```
Provider swap transaction simulation failed
```

### Root cause

The swap execution flow has three provider fallbacks:
1. **jupiter-v2-order** (`api.jup.ag/swap/v2`) — returns `errorCode: 1` with empty transaction for these tokens (server-side simulation fails on Jupiter's end)
2. **jupiter-ultra** (`lite-api.jup.ag/ultra/v1`) — also fails
3. **jupiter-metis** (`lite-api.jup.ag/swap/v1`) — returns a quote via **GoonFi V2**, then `build_swap_transaction` constructs the tx via V6 `/swap` — **local simulation fails**

GoonFi V2 does not correctly handle the combination of Token-2022 extensions present on these tokens. ZeroFi (the Backpack-controlled AMM) does handle them correctly — confirmed by the first successful sell going through ZeroFi via jupiter-v2-order.

## Fix

When a swap simulation failure is detected during `execute_swap_intent`, the next retry request passes `excludeDexes=GoonFi V2` to the Jupiter lite-api quote endpoint, forcing routing through a compatible DEX.

**`providers/jupiter.py`**
- Add `exclude_dexes: list[str] | None` parameter to `fetch_quote` and `_fetch_quote_direct`
- Pass as `excludeDexes` query parameter to Jupiter lite-api when set

**`wallet_layer/solana.py`**
- Propagate `exclude_dexes` through `preview_swap` into the metis fallback path
- In `execute_swap_intent`: track `_simulation_failed` flag; on retry after simulation failure, set `exclude_dexes=["GoonFi V2"]`

## Test

Manually tested SPCX→USDC sell (Backpack xStock, Token-2022 with 6 extensions):
- **Before**: all 3 attempts fail with simulation error
- **After**: attempt 1 fails (GoonFi V2), attempt 2 succeeds via ZeroFi ✅

## Notes

- This is a targeted fix, not a general Token-2022 solution. The broader issue is that Jupiter's aggregation doesn't know which DEXes are whitelisted by specific token issuers (Backpack Securities controls SPCX via `permanentDelegate`).
- The `excludeDexes` parameter is already supported by Jupiter's lite-api `/quote` endpoint — this PR just wires it through the call chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)