### PR TITLE
Harden wallet updater recovery and integration refresh

### DIFF
--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Smoke host integration ownership registry
         run: python agent-wallet/tests/smoke_integration_registry.py
 
+      - name: Smoke corrupt integration registry recovery
+        run: python agent-wallet/tests/smoke_update_recovers_corrupt_integration_registry.py
+
       - name: Smoke EVM wrong-home daemon recovery
         run: python agent-wallet/tests/smoke_openclaw_evm_runtime_restart_wrong_home.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Smoke staged install failure isolation
         run: python agent-wallet/tests/smoke_install_verify_rollback.py
 
+      - name: Smoke interrupted commit recovery
+        run: python agent-wallet/tests/smoke_update_recovers_interrupted_commit.py
+
       - name: Smoke editor path migration
         run: python agent-wallet/tests/smoke_update_repairs_editor_installs.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Smoke update lock
         run: python agent-wallet/tests/smoke_update_lock.py
 
+      - name: Smoke update recovery diagnostics
+        run: python agent-wallet/tests/smoke_update_recovery_status.py
+
       - name: Smoke editor path migration
         run: python agent-wallet/tests/smoke_update_repairs_editor_installs.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Smoke update recovery diagnostics
         run: python agent-wallet/tests/smoke_update_recovery_status.py
 
+      - name: Test update transaction state matrix
+        run: node --test agent-wallet/tests/update_transaction.test.mjs
+
       - name: Smoke editor path migration
         run: python agent-wallet/tests/smoke_update_repairs_editor_installs.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Smoke unmanaged integration preservation
         run: python agent-wallet/tests/smoke_update_preserves_unmanaged_integrations.py
 
+      - name: Smoke cross-home integration preservation
+        run: python agent-wallet/tests/smoke_update_preserves_cross_home_integrations.py
+
       - name: Smoke integration failure isolation
         run: python agent-wallet/tests/smoke_update_isolates_integration_failures.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Smoke unmanaged integration preservation
         run: python agent-wallet/tests/smoke_update_preserves_unmanaged_integrations.py
 
+      - name: Smoke integration failure isolation
+        run: python agent-wallet/tests/smoke_update_isolates_integration_failures.py
+
       - name: Smoke global CLI refresh
         run: python agent-wallet/tests/smoke_update_refreshes_global_cli.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Smoke verified boot-key resolution
         run: python agent-wallet/tests/smoke_boot_key_verified_resolution.py
 
+      - name: Smoke staged boot-key rejection
+        run: python agent-wallet/tests/smoke_install_rejects_unverified_boot_key.py
+
       - name: Smoke legacy update boot-key precedence
         run: python agent-wallet/tests/smoke_legacy_update_boot_key_precedence.py
 

--- a/.github/workflows/npm-installer.yml
+++ b/.github/workflows/npm-installer.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Smoke interrupted commit recovery
         run: python agent-wallet/tests/smoke_update_recovers_interrupted_commit.py
 
+      - name: Smoke update lock
+        run: python agent-wallet/tests/smoke_update_lock.py
+
       - name: Smoke editor path migration
         run: python agent-wallet/tests/smoke_update_repairs_editor_installs.py
 

--- a/agent-wallet/AGENTS.md
+++ b/agent-wallet/AGENTS.md
@@ -89,6 +89,7 @@ These instructions apply to the entire `agent-wallet/` tree.
   - installer scripts and README examples
 - When changing approval or signing behavior, update the runtime, adapter, CLI bridge, and smoke tests together.
 - If a change affects the OpenClaw bridge, update the TypeScript extension and the Python contract in the same change set.
+- Preserve the direct-upgrade floor and legacy removal policy documented in `UPGRADE_COMPATIBILITY.md`.
 
 ### Coding style
 - Follow existing Python style and type-hint usage.

--- a/agent-wallet/UPGRADE_COMPATIBILITY.md
+++ b/agent-wallet/UPGRADE_COMPATIBILITY.md
@@ -1,0 +1,36 @@
+# Upgrade Compatibility
+
+The wallet installer supports direct upgrades from older production releases.
+Compatibility code is removed according to the minimum supported source
+version, not according to elapsed time or a fixed number of releases.
+
+## Supported Floor
+
+The current regression floor is `0.1.53`. CI must keep a direct upgrade fixture
+at that floor until the project explicitly raises it in release documentation.
+
+Raising the floor requires all of the following:
+
+- a documented migration path for users below the new floor
+- upgrade fixtures for the new floor and the latest stable release
+- support and telemetry evidence that the retired path is no longer material
+- a release note naming the removed compatibility behavior
+
+## Compatibility Paths
+
+| Path | Purpose | Removal condition |
+|---|---|---|
+| JavaScript boot-key fallback | Updates runtimes that predate the verified Python installer resolver. | The supported floor includes `resolve_boot_key_for_installer`, and direct-upgrade fixtures no longer require the fallback. |
+| Directory runtime-pointer migration | Converts pre-versioned `current/` directories into release entries. | The supported floor guarantees symlink-based runtime pointers. |
+| Hermes legacy adoption | Recognizes an AgentLayer plugin installed before the ownership registry. | The supported floor guarantees an `integrations.json` Hermes ownership entry. |
+| Codex legacy adoption | Recognizes a matching local marketplace registration and AgentLayer manifest. | The supported floor guarantees an `integrations.json` Codex ownership entry. |
+| Claude Code legacy adoption | Recognizes the AgentLayer marketplace and plugin manifest before registry ownership. | The supported floor guarantees an `integrations.json` Claude Code ownership entry. |
+
+## Safety Rules
+
+- Legacy adoption requires independent registration and manifest evidence.
+- Unknown or externally managed integrations are never adopted automatically.
+- Compatibility paths must not weaken boot-key, sealed-state, approval, or
+  signing validation.
+- Every retained path needs a direct-upgrade smoke test or an explicit fixture
+  showing why it remains necessary.

--- a/agent-wallet/agent_wallet/boot_key_recovery.py
+++ b/agent-wallet/agent_wallet/boot_key_recovery.py
@@ -29,10 +29,19 @@ def export_boot_key() -> str:
 
 
 def import_boot_key(value: str) -> dict:
-    """Write a recorded boot key into the OS keystore and verify the read-back."""
+    """Validate and write a recorded boot key, then verify the read-back."""
     key = str(value or "").strip()
     if not key:
         raise WalletBackendError("A non-empty boot key is required for import.")
+    from agent_wallet.sealed_keys import resolve_sealed_keys_path, unseal_keys
+
+    if resolve_sealed_keys_path().exists():
+        try:
+            unseal_keys(key)
+        except Exception as exc:
+            raise WalletBackendError(
+                "The supplied boot key does not unlock the existing sealed wallet state."
+            ) from exc
     store = resolve_keystore()
     store.set(BOOT_KEY_ITEM, key)
     if store.get(BOOT_KEY_ITEM) != key:

--- a/agent-wallet/tests/e2e_install_new_user.py
+++ b/agent-wallet/tests/e2e_install_new_user.py
@@ -101,6 +101,12 @@ def main() -> None:
     env = dict(os.environ)
     env["OPENCLAW_HOME"] = str(temp_home)
     env["AGENT_WALLET_KEYSTORE_SERVICE"] = TEST_SERVICE
+    env["HERMES_HOME"] = str(temp_home / "hermes-home")
+    env["CODEX_HOME"] = str(temp_home / "codex-home")
+    env["AGENT_WALLET_CODEX_PLUGIN_ROOT"] = str(temp_home / "codex-plugins")
+    env["AGENT_WALLET_CODEX_MARKETPLACE_PATH"] = str(temp_home / "marketplace.json")
+    env["AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR"] = str(temp_home / "claude-marketplace")
+    env["AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT"] = str(temp_home / "claude-cache")
     for var in (
         "AGENT_WALLET_BOOT_KEY",
         "AGENT_WALLET_BOOT_KEY_FILE",

--- a/agent-wallet/tests/e2e_install_upgrade.py
+++ b/agent-wallet/tests/e2e_install_upgrade.py
@@ -73,6 +73,12 @@ def main() -> None:
     env = dict(os.environ)
     env["OPENCLAW_HOME"] = str(temp_home)
     env["AGENT_WALLET_KEYSTORE_SERVICE"] = TEST_SERVICE
+    env["HERMES_HOME"] = str(temp_home / "hermes-home")
+    env["CODEX_HOME"] = str(temp_home / "codex-home")
+    env["AGENT_WALLET_CODEX_PLUGIN_ROOT"] = str(temp_home / "codex-plugins")
+    env["AGENT_WALLET_CODEX_MARKETPLACE_PATH"] = str(temp_home / "marketplace.json")
+    env["AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR"] = str(temp_home / "claude-marketplace")
+    env["AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT"] = str(temp_home / "claude-cache")
     for var in (
         "AGENT_WALLET_BOOT_KEY",
         "AGENT_WALLET_BOOT_KEY_FILE",

--- a/agent-wallet/tests/smoke_boot_key_recovery.py
+++ b/agent-wallet/tests/smoke_boot_key_recovery.py
@@ -18,6 +18,7 @@ def main() -> None:
         shutil.rmtree(temp_home)
     os.environ["OPENCLAW_HOME"] = str(temp_home)
     os.environ["AGENT_WALLET_KEYSTORE_SERVICE"] = "ai.agentlayer.wallet.smoketest"
+    os.environ["AGENT_WALLET_KEYSTORE_BACKEND"] = "plaintext"
     for var in ("AGENT_WALLET_BOOT_KEY", "AGENT_WALLET_BOOT_KEY_FILE"):
         os.environ.pop(var, None)
 
@@ -29,6 +30,7 @@ def main() -> None:
     store.delete(BOOT_KEY_ITEM)
 
     from agent_wallet.boot_key_recovery import export_boot_key, import_boot_key
+    from agent_wallet.sealed_keys import seal_keys
 
     try:
         # No key yet -> export raises.
@@ -42,6 +44,18 @@ def main() -> None:
         status = import_boot_key("RECOVERED-KEY")
         assert status["imported"] is True, status
         assert config.read_boot_key_from_keystore() == "RECOVERED-KEY"
+
+        # Existing sealed state must be validated before the keystore is changed.
+        seal_keys("RECOVERED-KEY", {"master_key": "master", "approval_secret": "approval"})
+        try:
+            import_boot_key("STALE-RECOVERY-KEY")
+            raise AssertionError("stale import should have been rejected")
+        except WalletBackendError as exc:
+            assert "does not unlock" in str(exc)
+        assert store.get(BOOT_KEY_ITEM) == "RECOVERED-KEY"
+
+        # A valid re-import remains idempotent with sealed state present.
+        assert import_boot_key("RECOVERED-KEY")["imported"] is True
 
         # export now returns it.
         assert export_boot_key() == "RECOVERED-KEY"

--- a/agent-wallet/tests/smoke_cli_install_prefers_keystore_over_stale_boot_file.py
+++ b/agent-wallet/tests/smoke_cli_install_prefers_keystore_over_stale_boot_file.py
@@ -1,4 +1,4 @@
-"""Smoke test: CLI install prefers keystore over a stale boot-key file."""
+"""CLI install rejects stale explicit/file keys in favor of a verified keystore key."""
 
 from __future__ import annotations
 
@@ -10,6 +10,28 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+
+def _last_json(text: str) -> dict:
+    depth = 0
+    start = None
+    payloads: list[dict] = []
+    for index, char in enumerate(text):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                try:
+                    payloads.append(json.loads(text[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = None
+    if not payloads:
+        raise AssertionError(f"No JSON object found in: {text!r}")
+    return payloads[-1]
 
 
 def main() -> None:
@@ -91,6 +113,7 @@ def main() -> None:
             "AGENT_WALLET_APPROVAL_SECRET",
         }
     }
+    cli_env["AGENT_WALLET_BOOT_KEY"] = "stale-explicit-env-key"
     cli_env["AGENT_WALLET_VERIFY_DISABLE"] = "1"
 
     updated = subprocess.run(
@@ -113,6 +136,11 @@ def main() -> None:
     )
     updated_payload = json.loads(updated.stdout)
     assert updated_payload["ok"] is True
+    install_payload = _last_json(updated.stderr)
+    assert install_payload["boot_key_source"] == "runtime_verified", install_payload
+    assert keystore_path.read_text(encoding="utf-8").strip() == initial_env[
+        "AGENT_WALLET_BOOT_KEY"
+    ]
 
     status = subprocess.run(
         ["node", str(cli), "status"],

--- a/agent-wallet/tests/smoke_install_rejects_unverified_boot_key.py
+++ b/agent-wallet/tests/smoke_install_rejects_unverified_boot_key.py
@@ -1,0 +1,116 @@
+"""A pre-resolver runtime cannot carry a stale explicit key through staged commit."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _last_json(text: str) -> dict:
+    depth = 0
+    start = None
+    payloads: list[dict] = []
+    for index, char in enumerate(text):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                try:
+                    payloads.append(json.loads(text[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = None
+    if not payloads:
+        raise AssertionError(f"No JSON object found in: {text!r}")
+    return payloads[-1]
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-reject-unverified-boot-key-"))
+    try:
+        runtime_base = temp_root / "agent-wallet-runtime"
+        old_release = runtime_base / "releases" / "0.1.53"
+        old_package = old_release / "agent-wallet" / "agent_wallet"
+        old_package.mkdir(parents=True)
+        (old_package / "__init__.py").write_text("", encoding="utf-8")
+        (old_package / "config.py").write_text("# pre-resolver runtime\n", encoding="utf-8")
+        runtime_bin = old_release / "agent-wallet" / ".runtime-venv" / "bin"
+        runtime_bin.mkdir(parents=True)
+        runtime_python = runtime_bin / "python"
+        runtime_python.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8")
+        runtime_python.chmod(0o755)
+        (runtime_base / "current").symlink_to(old_release)
+
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENCLAW_HOME": str(temp_root),
+                "AGENT_WALLET_BOOT_KEY": "stale-explicit-key",
+                "AGENT_WALLET_KEYSTORE_BACKEND": "plaintext",
+                "AGENT_WALLET_PYTHON": sys.executable,
+                "AGENT_WALLET_VERIFY_DISABLE": "1",
+                "HERMES_HOME": str(temp_root / "hermes"),
+                "CODEX_HOME": str(temp_root / "codex-home"),
+                "AGENT_WALLET_CODEX_PLUGIN_ROOT": str(temp_root / "codex-plugins"),
+                "AGENT_WALLET_CODEX_MARKETPLACE_PATH": str(temp_root / "marketplace.json"),
+                "AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR": str(temp_root / "claude-marketplace"),
+                "AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT": str(temp_root / "claude-cache"),
+            }
+        )
+
+        os.environ.update(
+            {
+                "OPENCLAW_HOME": str(temp_root),
+                "AGENT_WALLET_KEYSTORE_BACKEND": "plaintext",
+            }
+        )
+        from agent_wallet.keystore import BOOT_KEY_ITEM, resolve_keystore
+        from agent_wallet.sealed_keys import seal_keys
+
+        correct_key = "correct-existing-key"
+        seal_keys(correct_key, {"master_key": "master", "approval_secret": "approval"})
+        store = resolve_keystore()
+        store.set(BOOT_KEY_ITEM, correct_key)
+
+        result = subprocess.run(
+            [
+                "node",
+                str(cli),
+                "install",
+                "--yes",
+                "--backend",
+                "none",
+                "--skip-python-setup",
+                "--skip-node-setup",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode != 0, result.stderr
+        payload = _last_json(result.stderr)
+        assert payload["category"] == "boot_key_rejected", payload
+        assert payload["switched_current"] is False, payload
+        assert (runtime_base / "current").resolve() == old_release.resolve()
+        assert store.get(BOOT_KEY_ITEM) == correct_key
+        assert "stale-explicit-key" not in result.stderr
+
+        print("smoke_install_rejects_unverified_boot_key: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/smoke_keystore_backend_state.py
+++ b/agent-wallet/tests/smoke_keystore_backend_state.py
@@ -27,6 +27,8 @@ def main() -> None:
         keystore.MacKeychainStore.get,
         keystore.MacKeychainStore.set,
         keystore.MacKeychainStore.delete,
+        keystore.WindowsDpapiStore.available,
+        keystore.LinuxSecretServiceStore.available,
     )
     try:
         keystore.MacKeychainStore.available = lambda _self: native_available
@@ -35,6 +37,8 @@ def main() -> None:
             lambda _self, name, value: native_values.__setitem__(name, value)
         )
         keystore.MacKeychainStore.delete = lambda _self, name: native_values.pop(name, None)
+        keystore.WindowsDpapiStore.available = lambda _self: False
+        keystore.LinuxSecretServiceStore.available = lambda _self: False
 
         store = keystore.resolve_keystore()
         assert store.backend_id == "macos-keychain"
@@ -73,6 +77,8 @@ def main() -> None:
             keystore.MacKeychainStore.get,
             keystore.MacKeychainStore.set,
             keystore.MacKeychainStore.delete,
+            keystore.WindowsDpapiStore.available,
+            keystore.LinuxSecretServiceStore.available,
         ) = original
         shutil.rmtree(home, ignore_errors=True)
 

--- a/agent-wallet/tests/smoke_update_isolates_integration_failures.py
+++ b/agent-wallet/tests/smoke_update_isolates_integration_failures.py
@@ -1,0 +1,103 @@
+"""A host integration failure cannot fail an already committed runtime update."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    version = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))["version"]
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-isolate-integration-failure-"))
+    try:
+        runtime_base = temp_root / "agent-wallet-runtime"
+        old_release = runtime_base / "releases" / "0.0.9"
+        old_plugin = old_release / "codex" / "plugins" / "agent-wallet"
+        _write_json(
+            old_plugin / ".codex-plugin" / "plugin.json",
+            {"name": "agent-wallet", "version": "0.0.9"},
+        )
+        (runtime_base / "current").symlink_to(old_release)
+
+        plugin_target = temp_root / "codex-plugins" / "agent-wallet"
+        plugin_target.parent.mkdir(parents=True)
+        plugin_target.symlink_to(old_plugin)
+        marketplace = temp_root / "marketplace.json"
+        marketplace.write_text("{not-json\n", encoding="utf-8")
+        _write_json(
+            runtime_base / "integrations.json",
+            {
+                "schema_version": 1,
+                "integrations": {
+                    "codex": {
+                        "managed": True,
+                        "installed_version": "0.0.9",
+                        "plugin_target": str(plugin_target),
+                        "marketplace_path": str(marketplace),
+                        "codex_home": str(temp_root / "codex-home"),
+                    }
+                },
+            },
+        )
+
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENCLAW_HOME": str(temp_root),
+                "OPENCLAW_AGENT_WALLET_UPDATE_CLI_PATH": str(cli),
+                "AGENT_WALLET_BOOT_KEY": "test-boot-key-integration-failure",
+                "AGENT_WALLET_MASTER_KEY": "test-master-key-integration-failure",
+                "AGENT_WALLET_APPROVAL_SECRET": "test-approval-integration-failure",
+                "AGENT_WALLET_VERIFY_DISABLE": "1",
+                "HERMES_HOME": str(temp_root / "hermes"),
+                "CODEX_HOME": str(temp_root / "codex-home"),
+                "AGENT_WALLET_CODEX_PLUGIN_ROOT": str(temp_root / "codex-plugins"),
+                "AGENT_WALLET_CODEX_MARKETPLACE_PATH": str(marketplace),
+                "AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR": str(temp_root / "claude-marketplace"),
+                "AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT": str(temp_root / "claude-cache"),
+            }
+        )
+        result = subprocess.run(
+            [
+                "node",
+                str(cli),
+                "update",
+                "--yes",
+                "--backend",
+                "none",
+                "--skip-python-setup",
+                "--skip-node-setup",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=300,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        codex = next(item for item in payload["integration_refresh"] if item["name"] == "codex")
+        assert codex["ok"] is False, codex
+        assert "JSON" in codex["error"], codex
+        assert payload["active_version"] == version, payload
+        assert (runtime_base / "current").resolve() == (
+            runtime_base / "releases" / version
+        ).resolve()
+
+        print("smoke_update_isolates_integration_failures: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/smoke_update_lock.py
+++ b/agent-wallet/tests/smoke_update_lock.py
@@ -1,0 +1,79 @@
+"""Concurrent installs are serialized and a live lock is never stolen."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+def _command(cli: Path) -> list[str]:
+    return [
+        "node",
+        str(cli),
+        "install",
+        "--yes",
+        "--backend",
+        "none",
+        "--skip-python-setup",
+        "--skip-node-setup",
+    ]
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-update-lock-"))
+    try:
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENCLAW_HOME": str(temp_root),
+                "AGENT_WALLET_BOOT_KEY": "test-boot-key-update-lock",
+                "AGENT_WALLET_MASTER_KEY": "test-master-key-update-lock",
+                "AGENT_WALLET_APPROVAL_SECRET": "test-approval-update-lock",
+                "AGENT_WALLET_VERIFY_DISABLE": "1",
+                "HERMES_HOME": str(temp_root / "hermes"),
+                "CODEX_HOME": str(temp_root / "codex-home"),
+                "AGENT_WALLET_CODEX_PLUGIN_ROOT": str(temp_root / "codex-plugins"),
+                "AGENT_WALLET_CODEX_MARKETPLACE_PATH": str(temp_root / "marketplace.json"),
+                "AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR": str(temp_root / "claude-marketplace"),
+                "AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT": str(temp_root / "claude-cache"),
+            }
+        )
+        first = subprocess.Popen(
+            _command(cli),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**env, "AGENT_WALLET_TEST_HOLD_LOCK_MS": "3000"},
+        )
+        owner_path = temp_root / "agent-wallet-runtime" / "update.lock" / "owner.json"
+        for _ in range(100):
+            if owner_path.exists():
+                break
+            time.sleep(0.05)
+        assert owner_path.exists(), "first installer did not acquire the lock"
+
+        second = subprocess.run(
+            _command(cli), capture_output=True, text=True, env=env, timeout=30
+        )
+        assert second.returncode != 0, second.stderr
+        assert '"category": "update_locked"' in second.stderr, second.stderr
+        assert "test-boot-key" not in second.stderr
+
+        first_stdout, first_stderr = first.communicate(timeout=300)
+        assert first.returncode == 0, (first_stdout, first_stderr)
+        assert not owner_path.parent.exists()
+
+        print("smoke_update_lock: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/smoke_update_preserves_cross_home_integrations.py
+++ b/agent-wallet/tests/smoke_update_preserves_cross_home_integrations.py
@@ -1,0 +1,119 @@
+"""Legacy adoption never claims AgentLayer integrations from another runtime home."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-preserve-cross-home-"))
+    try:
+        home = temp_root / "isolated-home"
+        runtime_base = home / "agent-wallet-runtime"
+        old_release = runtime_base / "releases" / "0.0.9"
+        old_release.mkdir(parents=True)
+        (runtime_base / "current").symlink_to(old_release)
+
+        external = temp_root / "production-runtime" / "releases" / "0.1.75"
+        hermes_source = external / "hermes" / "plugins" / "agent_wallet"
+        codex_source = external / "codex" / "plugins" / "agent-wallet"
+        claude_source = external / "claude-code" / "plugins" / "agent-wallet"
+        hermes_source.mkdir(parents=True)
+        (hermes_source / "plugin.yaml").write_text("name: agent_wallet\n", encoding="utf-8")
+        _write_json(codex_source / ".codex-plugin" / "plugin.json", {"name": "agent-wallet"})
+        _write_json(claude_source / ".claude-plugin" / "plugin.json", {"name": "agent-wallet"})
+
+        hermes_home = temp_root / "hermes"
+        hermes_target = hermes_home / "plugins" / "agent_wallet"
+        hermes_target.parent.mkdir(parents=True)
+        hermes_target.symlink_to(hermes_source)
+
+        codex_root = temp_root / "codex-plugins"
+        codex_target = codex_root / "agent-wallet"
+        codex_target.parent.mkdir(parents=True)
+        codex_target.symlink_to(codex_source)
+        codex_marketplace = temp_root / "marketplace.json"
+        _write_json(
+            codex_marketplace,
+            {
+                "name": "local",
+                "plugins": [
+                    {"name": "agent-wallet", "source": {"source": "local", "path": "./plugins/agent-wallet"}}
+                ],
+            },
+        )
+
+        claude_marketplace = temp_root / "claude-marketplace"
+        claude_target = claude_marketplace / "plugins" / "agent-wallet"
+        claude_target.parent.mkdir(parents=True)
+        claude_target.symlink_to(claude_source)
+        _write_json(
+            claude_marketplace / ".claude-plugin" / "marketplace.json",
+            {"name": "agentlayer-local", "plugins": [{"name": "agent-wallet"}]},
+        )
+
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENCLAW_HOME": str(home),
+                "OPENCLAW_AGENT_WALLET_UPDATE_CLI_PATH": str(cli),
+                "AGENT_WALLET_BOOT_KEY": "test-cross-home-boot-key",
+                "AGENT_WALLET_MASTER_KEY": "test-cross-home-master-key",
+                "AGENT_WALLET_APPROVAL_SECRET": "test-cross-home-approval",
+                "AGENT_WALLET_VERIFY_DISABLE": "1",
+                "HERMES_HOME": str(hermes_home),
+                "CODEX_HOME": str(temp_root / "codex-home"),
+                "AGENT_WALLET_CODEX_PLUGIN_ROOT": str(codex_root),
+                "AGENT_WALLET_CODEX_MARKETPLACE_PATH": str(codex_marketplace),
+                "AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR": str(claude_marketplace),
+                "AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT": str(temp_root / "claude-cache"),
+            }
+        )
+        result = subprocess.run(
+            [
+                "node",
+                str(cli),
+                "update",
+                "--yes",
+                "--backend",
+                "none",
+                "--skip-python-setup",
+                "--skip-node-setup",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+            timeout=300,
+        )
+        payload = json.loads(result.stdout)
+        refreshed = {item["name"] for item in payload["integration_refresh"]}
+        assert "hermes" not in refreshed, payload
+        assert "codex" not in refreshed, payload
+        assert "claude-code" not in refreshed, payload
+        assert hermes_target.resolve() == hermes_source.resolve()
+        assert codex_target.resolve() == codex_source.resolve()
+        assert claude_target.resolve() == claude_source.resolve()
+
+        registry = json.loads((runtime_base / "integrations.json").read_text(encoding="utf-8"))
+        assert set(registry["integrations"]) == {"openclaw"}, registry
+
+        print("smoke_update_preserves_cross_home_integrations: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/smoke_update_recovers_corrupt_integration_registry.py
+++ b/agent-wallet/tests/smoke_update_recovers_corrupt_integration_registry.py
@@ -1,0 +1,96 @@
+"""A corrupt integration registry is preserved and cannot fail runtime update."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    version = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))["version"]
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-corrupt-integration-registry-"))
+    try:
+        runtime_base = temp_root / "agent-wallet-runtime"
+        old_release = runtime_base / "releases" / "0.0.9"
+        old_release.mkdir(parents=True)
+        (runtime_base / "current").symlink_to(old_release)
+        registry_path = runtime_base / "integrations.json"
+        corrupt_contents = '{"schema_version":1,"integrations":'
+        registry_path.write_text(corrupt_contents, encoding="utf-8")
+
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENCLAW_HOME": str(temp_root),
+                "OPENCLAW_AGENT_WALLET_UPDATE_CLI_PATH": str(cli),
+                "AGENT_WALLET_BOOT_KEY": "test-corrupt-registry-boot-key",
+                "AGENT_WALLET_MASTER_KEY": "test-corrupt-registry-master-key",
+                "AGENT_WALLET_APPROVAL_SECRET": "test-corrupt-registry-approval",
+                "AGENT_WALLET_VERIFY_DISABLE": "1",
+                "HERMES_HOME": str(temp_root / "hermes"),
+                "CODEX_HOME": str(temp_root / "codex-home"),
+                "AGENT_WALLET_CODEX_PLUGIN_ROOT": str(temp_root / "codex-plugins"),
+                "AGENT_WALLET_CODEX_MARKETPLACE_PATH": str(temp_root / "marketplace.json"),
+                "AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR": str(temp_root / "claude-marketplace"),
+                "AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT": str(temp_root / "claude-cache"),
+            }
+        )
+
+        before = subprocess.run(
+            ["node", str(cli), "status"], capture_output=True, text=True, check=True, env=env
+        )
+        before_status = json.loads(before.stdout)["framework_integrations"]
+        assert before_status["registry_ok"] is False, before_status
+        assert before_status["in_sync"] is False, before_status
+        assert registry_path.read_text(encoding="utf-8") == corrupt_contents
+
+        update = subprocess.run(
+            [
+                "node",
+                str(cli),
+                "update",
+                "--yes",
+                "--backend",
+                "none",
+                "--skip-python-setup",
+                "--skip-node-setup",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+            timeout=300,
+        )
+        payload = json.loads(update.stdout)
+        assert payload["active_version"] == version, payload
+        assert (runtime_base / "current").resolve() == (
+            runtime_base / "releases" / version
+        ).resolve()
+
+        backups = list(runtime_base.glob("integrations.json.corrupt-*"))
+        assert len(backups) == 1, backups
+        assert backups[0].read_text(encoding="utf-8") == corrupt_contents
+        recovered = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert set(recovered["integrations"]) == {"openclaw"}, recovered
+        assert recovered["recovered_corrupt_registry"] == backups[0].name, recovered
+
+        after = subprocess.run(
+            ["node", str(cli), "status"], capture_output=True, text=True, check=True, env=env
+        )
+        after_status = json.loads(after.stdout)["framework_integrations"]
+        assert after_status["registry_ok"] is True, after_status
+        assert after_status["recovered_corrupt_registry"] == backups[0].name, after_status
+
+        print("smoke_update_recovers_corrupt_integration_registry: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/smoke_update_recovers_interrupted_commit.py
+++ b/agent-wallet/tests/smoke_update_recovers_interrupted_commit.py
@@ -1,0 +1,115 @@
+"""A same-version crash after release backup is recovered before the next install."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _last_json(text: str) -> dict:
+    depth = 0
+    start = None
+    payloads: list[dict] = []
+    for index, char in enumerate(text):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                try:
+                    payloads.append(json.loads(text[start : index + 1]))
+                except json.JSONDecodeError:
+                    pass
+                start = None
+    if not payloads:
+        raise AssertionError(f"No JSON object found in: {text!r}")
+    return payloads[-1]
+
+
+def _install(cli: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "node",
+            str(cli),
+            "install",
+            "--yes",
+            "--backend",
+            "none",
+            "--skip-python-setup",
+            "--skip-node-setup",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-recover-interrupted-commit-"))
+    try:
+        env = dict(os.environ)
+        env.update(
+            {
+                "OPENCLAW_HOME": str(temp_root),
+                "AGENT_WALLET_BOOT_KEY": "test-boot-key-interrupted-commit",
+                "AGENT_WALLET_MASTER_KEY": "test-master-key-interrupted-commit",
+                "AGENT_WALLET_APPROVAL_SECRET": "test-approval-interrupted-commit",
+                "AGENT_WALLET_VERIFY_DISABLE": "1",
+                "HERMES_HOME": str(temp_root / "hermes"),
+                "CODEX_HOME": str(temp_root / "codex-home"),
+                "AGENT_WALLET_CODEX_PLUGIN_ROOT": str(temp_root / "codex-plugins"),
+                "AGENT_WALLET_CODEX_MARKETPLACE_PATH": str(temp_root / "marketplace.json"),
+                "AGENT_WALLET_CLAUDE_CODE_MARKETPLACE_DIR": str(temp_root / "claude-marketplace"),
+                "AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT": str(temp_root / "claude-cache"),
+            }
+        )
+        first = _install(cli, env)
+        assert first.returncode == 0, first.stderr
+
+        runtime_base = temp_root / "agent-wallet-runtime"
+        current = runtime_base / "current"
+        release = current.resolve()
+        assert release.exists()
+
+        interrupted = _install(
+            cli,
+            {**env, "AGENT_WALLET_TEST_EXIT_AFTER_RELEASE_RENAME": "1"},
+        )
+        assert interrupted.returncode == 86, interrupted.stderr
+        assert current.is_symlink() and not current.exists()
+        journal = json.loads((runtime_base / "update-journal.json").read_text(encoding="utf-8"))
+        assert journal["state"] == "committing", journal
+        assert not Path(journal["release_root"]).exists(), journal
+        assert Path(journal["replaced_root"]).exists(), journal
+
+        recovered = _install(cli, env)
+        assert recovered.returncode == 0, recovered.stderr
+        payload = _last_json(recovered.stderr)
+        assert payload["recovery"] == {
+            "attempted": True,
+            "ok": True,
+            "action": "restored_replaced_release",
+        }, payload
+        assert current.exists()
+        assert current.resolve() == release
+        final_journal = json.loads(
+            (runtime_base / "update-journal.json").read_text(encoding="utf-8")
+        )
+        assert final_journal["state"] == "committed", final_journal
+
+        print("smoke_update_recovers_interrupted_commit: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/smoke_update_recovers_interrupted_commit.py
+++ b/agent-wallet/tests/smoke_update_recovers_interrupted_commit.py
@@ -90,6 +90,7 @@ def main() -> None:
         assert journal["state"] == "committing", journal
         assert not Path(journal["release_root"]).exists(), journal
         assert Path(journal["replaced_root"]).exists(), journal
+        assert (runtime_base / "update.lock").exists()
 
         recovered = _install(cli, env)
         assert recovered.returncode == 0, recovered.stderr
@@ -101,6 +102,7 @@ def main() -> None:
         }, payload
         assert current.exists()
         assert current.resolve() == release
+        assert not (runtime_base / "update.lock").exists()
         final_journal = json.loads(
             (runtime_base / "update-journal.json").read_text(encoding="utf-8")
         )

--- a/agent-wallet/tests/smoke_update_recovery_status.py
+++ b/agent-wallet/tests/smoke_update_recovery_status.py
@@ -1,0 +1,72 @@
+"""Status and doctor report interrupted updates without mutating recovery state."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _run(cli: Path, command: str, env: dict[str, str]) -> dict:
+    result = subprocess.run(
+        ["node", str(cli), command], capture_output=True, text=True, env=env, timeout=60
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cli = repo_root / "bin" / "openclaw-agent-wallet.mjs"
+    temp_root = Path(tempfile.mkdtemp(prefix="openclaw-update-recovery-status-"))
+    try:
+        runtime_base = temp_root / "agent-wallet-runtime"
+        releases = runtime_base / "releases"
+        replaced = releases / "0.1.75-replaced"
+        staging = releases / ".staging-0.1.75-test"
+        replaced.mkdir(parents=True)
+        staging.mkdir()
+        release = releases / "0.1.75"
+        (runtime_base / "current").symlink_to(release)
+        journal_path = runtime_base / "update-journal.json"
+        journal_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "state": "committing",
+                    "version": "0.1.75",
+                    "staging_root": str(staging),
+                    "release_root": str(release),
+                    "replaced_root": str(replaced),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        env = {**os.environ, "OPENCLAW_HOME": str(temp_root)}
+
+        status = _run(cli, "status", env)
+        assert status["schema_version"] == 1, status
+        recovery = status["update_recovery"]
+        assert recovery["state"] == "committing", recovery
+        assert recovery["needs_recovery"] is True, recovery
+        assert recovery["current_resolves"] is False, recovery
+
+        doctor = _run(cli, "doctor", env)
+        assert doctor["schema_version"] == 1, doctor
+        check = next(item for item in doctor["checks"] if item["name"] == "update_recovery_state")
+        assert check["needs_recovery"] is True, check
+        assert check["fix"] == "wallet install --yes", check
+
+        assert json.loads(journal_path.read_text(encoding="utf-8"))["state"] == "committing"
+        assert replaced.exists() and staging.exists()
+
+        print("smoke_update_recovery_status: ok")
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-wallet/tests/update_transaction.test.mjs
+++ b/agent-wallet/tests/update_transaction.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createUpdateTransactionManager } from "../../bin/lib/update-transaction.mjs";
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-wallet-transaction-"));
+  const runtimeBase = path.join(root, "agent-wallet-runtime");
+  const releases = path.join(runtimeBase, "releases");
+  fs.mkdirSync(releases, { recursive: true });
+  const active = path.join(releases, "known-good");
+  fs.mkdirSync(active);
+  fs.symlinkSync(active, path.join(runtimeBase, "current"), "dir");
+  const manager = createUpdateTransactionManager({
+    runtimeBase,
+    packageVersion: "9.9.9",
+    env: {},
+  });
+  return { root, runtimeBase, releases, active, manager };
+}
+
+function cleanup(context) {
+  fs.rmSync(context.root, { recursive: true, force: true });
+}
+
+for (const state of ["preparing", "verified"]) {
+  test(`${state} staging is quarantined without changing current`, () => {
+    const context = fixture();
+    try {
+      const staging = path.join(context.releases, `.staging-${state}`);
+      const release = path.join(context.releases, "9.9.9");
+      fs.mkdirSync(staging);
+      context.manager.writeJournal(state, {
+        staging_root: staging,
+        release_root: release,
+      });
+
+      const recovery = context.manager.recover();
+      assert.equal(recovery.ok, true);
+      assert.equal(recovery.action, "quarantined_incomplete_staging");
+      assert.equal(fs.existsSync(staging), false);
+      assert.equal(fs.existsSync(recovery.quarantined_runtime), true);
+      assert.equal(fs.realpathSync(path.join(context.runtimeBase, "current")), fs.realpathSync(context.active));
+      assert.equal(context.manager.readJournal().state, "recovered");
+    } finally {
+      cleanup(context);
+    }
+  });
+}
+
+test("present committed release is accepted and recovery is idempotent", () => {
+  const context = fixture();
+  try {
+    const release = path.join(context.releases, "9.9.9");
+    fs.mkdirSync(release);
+    context.manager.writeJournal("committing", {
+      staging_root: path.join(context.releases, ".staging-missing"),
+      release_root: release,
+      replaced_root: path.join(context.releases, "9.9.9-replaced"),
+    });
+
+    assert.deepEqual(context.manager.recover(), {
+      attempted: true,
+      ok: true,
+      action: "release_already_present",
+    });
+    assert.deepEqual(context.manager.recover(), {
+      attempted: false,
+      ok: true,
+      reason: "no interrupted update",
+    });
+    assert.equal(fs.realpathSync(path.join(context.runtimeBase, "current")), fs.realpathSync(context.active));
+  } finally {
+    cleanup(context);
+  }
+});
+
+test("journal paths outside runtime base are rejected without mutation", () => {
+  const context = fixture();
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "agent-wallet-outside-"));
+  try {
+    context.manager.writeJournal("verified", {
+      staging_root: outside,
+      release_root: path.join(context.releases, "9.9.9"),
+    });
+    const recovery = context.manager.recover();
+    assert.equal(recovery.ok, false);
+    assert.match(recovery.reason, /unsafe path/);
+    assert.equal(fs.existsSync(outside), true);
+    assert.equal(context.manager.readJournal().state, "verified");
+  } finally {
+    fs.rmSync(outside, { recursive: true, force: true });
+    cleanup(context);
+  }
+});
+
+test("corrupt journal is diagnosed and never rewritten by recovery", () => {
+  const context = fixture();
+  try {
+    fs.writeFileSync(context.manager.journalPath, "{not-json\n");
+    const before = fs.readFileSync(context.manager.journalPath, "utf8");
+    assert.equal(context.manager.status().journal_ok, false);
+    const recovery = context.manager.recover();
+    assert.equal(recovery.ok, false);
+    assert.match(recovery.reason, /corrupt/);
+    assert.equal(fs.readFileSync(context.manager.journalPath, "utf8"), before);
+  } finally {
+    cleanup(context);
+  }
+});
+
+for (const owner of [
+  { schema_version: 1, pid: 999999, hostname: "another-host", token: "foreign" },
+  "{not-json\n",
+]) {
+  const label = typeof owner === "string" ? "unreadable" : "foreign-host";
+  test(`${label} lock is not stolen`, () => {
+    const context = fixture();
+    try {
+      fs.mkdirSync(context.manager.lockPath);
+      const ownerPath = path.join(context.manager.lockPath, "owner.json");
+      fs.writeFileSync(ownerPath, typeof owner === "string" ? owner : JSON.stringify(owner));
+      const lock = context.manager.acquireLock();
+      assert.equal(lock.ok, false);
+      assert.equal(fs.existsSync(context.manager.lockPath), true);
+      assert.equal(fs.readFileSync(ownerPath, "utf8"), typeof owner === "string" ? owner : JSON.stringify(owner));
+    } finally {
+      cleanup(context);
+    }
+  });
+}

--- a/bin/lib/boot-key.mjs
+++ b/bin/lib/boot-key.mjs
@@ -1,0 +1,185 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function readEnv(pathname) {
+  try {
+    const result = {};
+    for (const line of fs.readFileSync(pathname, "utf8").split(/\r?\n/)) {
+      const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (match) result[match[1]] = match[2];
+    }
+    return result;
+  } catch (error) {
+    if (error?.code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+function readText(pathname) {
+  try {
+    return fs.readFileSync(pathname, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return "";
+    throw error;
+  }
+}
+
+function writeSecret(pathname, value) {
+  fs.mkdirSync(path.dirname(pathname), { recursive: true });
+  fs.writeFileSync(pathname, `${String(value || "").trim()}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(pathname, 0o600);
+  } catch {
+    // Best effort on filesystems without POSIX modes.
+  }
+}
+
+export function createBootKeyManager({
+  runtimeBase,
+  openclawHome,
+  currentRuntimeRoot,
+  resolveVenvPython,
+  expandHome,
+  bridgeTimeoutMs,
+  env = process.env,
+}) {
+  const defaultFile = path.join(runtimeBase, "boot-key");
+
+  function currentKey() {
+    const root = currentRuntimeRoot();
+    if (!root) return "";
+    return readEnv(path.join(root, "agent-wallet", ".env")).AGENT_WALLET_BOOT_KEY || "";
+  }
+
+  function configuredFileKey() {
+    const value = String(env.AGENT_WALLET_BOOT_KEY_FILE || "").trim();
+    return value ? readText(path.resolve(expandHome(value))).trim() : "";
+  }
+
+  function ensureFile() {
+    const configured = String(env.AGENT_WALLET_BOOT_KEY_FILE || "").trim();
+    const keyFile = configured ? path.resolve(expandHome(configured)) : defaultFile;
+    if (readText(keyFile).trim()) return { path: keyFile, status: "existing" };
+    const key = String(env.AGENT_WALLET_BOOT_KEY || "").trim() || configuredFileKey() || currentKey();
+    if (!key) return { path: keyFile, status: "missing" };
+    writeSecret(keyFile, key);
+    return { path: keyFile, status: "created" };
+  }
+
+  function readKeystore() {
+    const root = currentRuntimeRoot();
+    if (!root) return "";
+    const python = resolveVenvPython(root);
+    if (!python) return "";
+    try {
+      const result = spawnSync(
+        python,
+        ["-c", "from agent_wallet.config import read_boot_key_from_keystore as r; print(r())"],
+        {
+          cwd: path.join(root, "agent-wallet"),
+          encoding: "utf8",
+          timeout: bridgeTimeoutMs,
+          env: { ...env, OPENCLAW_HOME: openclawHome },
+        },
+      );
+      return result.status === 0 ? String(result.stdout || "").trim() : "";
+    } catch {
+      return "";
+    }
+  }
+
+  function resolveFromRuntime() {
+    const root = currentRuntimeRoot();
+    if (!root) return { supported: false, key: "" };
+    const python = resolveVenvPython(root);
+    if (!python) return { supported: false, key: "" };
+    try {
+      const result = spawnSync(
+        python,
+        ["-c", "from agent_wallet.config import resolve_boot_key_for_installer as r; print(r())"],
+        {
+          cwd: path.join(root, "agent-wallet"),
+          encoding: "utf8",
+          timeout: bridgeTimeoutMs,
+          env: { ...env, OPENCLAW_HOME: openclawHome },
+        },
+      );
+      return result.status === 0
+        ? { supported: true, key: String(result.stdout || "").trim() }
+        : { supported: false, key: "" };
+    } catch {
+      return { supported: false, key: "" };
+    }
+  }
+
+  function resolveLegacy() {
+    for (const [source, key] of [
+      ["legacy_keystore", readKeystore()],
+      ["current_runtime_env", currentKey()],
+      ["configured_file", configuredFileKey()],
+      ["default_file", readText(defaultFile).trim()],
+    ]) {
+      if (key) return { key, source };
+    }
+    return { key: "", source: "none" };
+  }
+
+  function provision(releaseRoot, bootKey) {
+    const key = String(bootKey || "").trim();
+    if (!key) return false;
+    const python = resolveVenvPython(releaseRoot);
+    if (!python) return false;
+    try {
+      const result = spawnSync(
+        python,
+        ["-m", "agent_wallet.openclaw_cli", "boot-key-import", "--key-stdin"],
+        {
+          cwd: path.join(releaseRoot, "agent-wallet"),
+          input: key,
+          encoding: "utf8",
+          timeout: bridgeTimeoutMs,
+          env: { ...env, OPENCLAW_HOME: openclawHome },
+        },
+      );
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  function verifyWithRuntime(releaseRoot) {
+    const sealedPath = path.join(openclawHome, "sealed_keys.json");
+    if (!fs.existsSync(sealedPath)) return { ok: true, required: false };
+    const key = String(env.AGENT_WALLET_BOOT_KEY || "").trim();
+    if (!key) return { ok: false, required: true, error: "no verified boot key is available" };
+    const python =
+      env.AGENT_WALLET_PYTHON ||
+      env.OPENCLAW_AGENT_WALLET_PYTHON ||
+      resolveVenvPython(releaseRoot);
+    if (!python) {
+      if (String(env.AGENT_WALLET_VERIFY_DISABLE || "") === "1") {
+        return { ok: true, required: true, skipped: true };
+      }
+      return { ok: false, required: true, error: "staged Python runtime is unavailable" };
+    }
+    const result = spawnSync(
+      python,
+      [
+        "-c",
+        "from agent_wallet.sealed_keys import unseal_keys; import os; unseal_keys(os.environ['AGENT_WALLET_BOOT_KEY']); print('ok')",
+      ],
+      {
+        cwd: path.join(releaseRoot, "agent-wallet"),
+        encoding: "utf8",
+        timeout: bridgeTimeoutMs,
+        env: { ...env, OPENCLAW_HOME: openclawHome },
+      },
+    );
+    return result.status === 0
+      ? { ok: true, required: true }
+      : { ok: false, required: true, error: "selected boot key does not unlock sealed wallet state" };
+  }
+
+  return { ensureFile, resolveFromRuntime, resolveLegacy, provision, verifyWithRuntime };
+}

--- a/bin/lib/integrations.mjs
+++ b/bin/lib/integrations.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 
 function readJson(pathname) {
   try {
@@ -99,4 +100,273 @@ export function createIntegrationManager({ runtimeBase, packageVersion, activeVe
   }
 
   return { registryPath, readRegistry, record, managed, status, safelyRefresh, refreshAll };
+}
+
+export function createHostIntegrationManager({
+  env,
+  packageRoot,
+  registry,
+  currentRuntimePath,
+  openclawHome,
+  hermesHome,
+  codexHome,
+  codexPluginRoot,
+  codexMarketplacePath,
+  claudeMarketplaceDir,
+  claudeMarketplaceName,
+  expandHome,
+  resolveVenvPython,
+  commandPath,
+  repairRuntimeSymlink,
+  repairHermesEnv,
+  ensureCodexMarketplaceEntry,
+  ensureClaudeCodeMarketplace,
+  pinClaudeCacheCopies,
+}) {
+  function symlinkManifestMatches(linkPath, manifestRelativePath, expectedName) {
+    try {
+      if (!fs.lstatSync(linkPath).isSymbolicLink()) return false;
+      const target = path.resolve(path.dirname(linkPath), fs.readlinkSync(linkPath));
+      return readJson(path.join(target, manifestRelativePath))?.name === expectedName;
+    } catch {
+      return false;
+    }
+  }
+
+  function adoptHermes() {
+    const pluginTarget = path.join(hermesHome, "plugins", "agent_wallet");
+    let target;
+    try {
+      if (!fs.lstatSync(pluginTarget).isSymbolicLink()) return null;
+      target = path.resolve(path.dirname(pluginTarget), fs.readlinkSync(pluginTarget));
+    } catch {
+      return null;
+    }
+    let manifest = "";
+    try {
+      manifest = fs.readFileSync(path.join(target, "plugin.yaml"), "utf8");
+    } catch {
+      return null;
+    }
+    if (!/^name:\s*agent[-_]wallet\s*$/m.test(manifest)) return null;
+    return registry.record("hermes", {
+      hermes_home: hermesHome,
+      plugin_target: pluginTarget,
+      env_path: path.join(hermesHome, ".env"),
+      adopted_legacy_install: true,
+    });
+  }
+
+  function adoptCodex() {
+    let marketplace;
+    try {
+      marketplace = readJson(codexMarketplacePath);
+    } catch {
+      return null;
+    }
+    const pluginTarget = path.join(codexPluginRoot, "agent-wallet");
+    const registered = Array.isArray(marketplace?.plugins) && marketplace.plugins.some(
+      (item) => item?.name === "agent-wallet" && item?.source?.source === "local",
+    );
+    if (!registered || !symlinkManifestMatches(pluginTarget, ".codex-plugin/plugin.json", "agent-wallet")) {
+      return null;
+    }
+    return registry.record("codex", {
+      codex_home: codexHome,
+      plugin_target: pluginTarget,
+      marketplace_path: codexMarketplacePath,
+      marketplace_name: String(marketplace.name || "local"),
+      adopted_legacy_install: true,
+    });
+  }
+
+  function adoptClaudeCode() {
+    let manifest;
+    try {
+      manifest = readJson(path.join(claudeMarketplaceDir, ".claude-plugin", "marketplace.json"));
+    } catch {
+      return null;
+    }
+    const pluginTarget = path.join(claudeMarketplaceDir, "plugins", "agent-wallet");
+    const registered = manifest?.name === claudeMarketplaceName &&
+      Array.isArray(manifest.plugins) && manifest.plugins.some((item) => item?.name === "agent-wallet");
+    if (!registered || !symlinkManifestMatches(pluginTarget, ".claude-plugin/plugin.json", "agent-wallet")) {
+      return null;
+    }
+    return registry.record("claude-code", {
+      marketplace_dir: claudeMarketplaceDir,
+      plugin_target: pluginTarget,
+      cache_root: path.resolve(expandHome(env.AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT || "~/.claude/plugins/cache")),
+      adopted_legacy_install: true,
+    });
+  }
+
+  function runHostRefresh(command, args, commandEnv = env) {
+    const binary = commandPath(command);
+    if (!binary) {
+      return { attempted: false, ok: false, error: `${command} CLI not found`, fix: args.join(" ") };
+    }
+    const result = spawnSync(binary, args, { cwd: packageRoot, encoding: "utf8", env: commandEnv });
+    return {
+      attempted: true,
+      ok: result.status === 0,
+      error: result.status === 0 ? "" : (result.stderr || result.stdout || "").trim(),
+      fix: result.status === 0 ? "" : `${command} ${args.join(" ")}`,
+    };
+  }
+
+  function refreshOpenclaw() {
+    const entry = registry.managed("openclaw");
+    if (!entry) {
+      return { name: "openclaw", attempted: false, ok: true, repaired: false, reason: "not managed" };
+    }
+    const configPath = path.resolve(expandHome(entry.config_path || path.join(openclawHome, "openclaw.json")));
+    let config;
+    try {
+      config = readJson(configPath);
+    } catch (error) {
+      return { name: "openclaw", attempted: true, ok: false, repaired: false, error: error.message };
+    }
+    if (!config || typeof config !== "object") {
+      return { name: "openclaw", attempted: true, ok: false, repaired: false, error: `missing ${configPath}` };
+    }
+    const extensionPath = path.join(currentRuntimePath, ".openclaw", "extensions", "agent-wallet");
+    const walletPackageRoot = path.join(currentRuntimePath, "agent-wallet");
+    const pythonBin = resolveVenvPython(currentRuntimePath);
+    const plugins = config.plugins && typeof config.plugins === "object" ? config.plugins : (config.plugins = {});
+    const load = plugins.load && typeof plugins.load === "object" ? plugins.load : (plugins.load = {});
+    const paths = Array.isArray(load.paths) ? load.paths : [];
+    load.paths = [
+      ...paths.filter((item) => !String(item || "").replaceAll("\\", "/").endsWith("/.openclaw/extensions/agent-wallet")),
+      extensionPath,
+    ];
+    const entries = plugins.entries && typeof plugins.entries === "object" ? plugins.entries : (plugins.entries = {});
+    const walletEntry = entries["agent-wallet"];
+    if (!walletEntry || typeof walletEntry !== "object") {
+      return { name: "openclaw", attempted: false, ok: true, repaired: false, reason: "plugin entry not configured" };
+    }
+    walletEntry.enabled = true;
+    walletEntry.config = walletEntry.config && typeof walletEntry.config === "object" ? walletEntry.config : {};
+    walletEntry.config.packageRoot = walletPackageRoot;
+    if (pythonBin) walletEntry.config.pythonBin = pythonBin;
+    writeJsonAtomic(configPath, config);
+    registry.record("openclaw", {
+      config_path: configPath,
+      extension_path: extensionPath,
+      package_root: walletPackageRoot,
+      restart_required: true,
+    });
+    return { name: "openclaw", attempted: true, ok: true, repaired: true, config_path: configPath, restart_required: true };
+  }
+
+  function refreshHermes() {
+    const entry = registry.managed("hermes") || adoptHermes();
+    if (!entry) return null;
+    const target = path.resolve(expandHome(entry.plugin_target));
+    const envPath = path.resolve(expandHome(entry.env_path));
+    const result = repairRuntimeSymlink(
+      "hermes",
+      target,
+      path.join(currentRuntimePath, "hermes", "plugins", "agent_wallet"),
+      env,
+      { allowExternal: true },
+    );
+    result.env_repaired = repairHermesEnv(envPath, env);
+    result.restart_required = true;
+    if (result.ok) {
+      registry.record("hermes", { ...entry, plugin_target: target, env_path: envPath, restart_required: true });
+    }
+    return result;
+  }
+
+  function refreshCodex() {
+    const entry = registry.managed("codex") || adoptCodex();
+    if (!entry) return null;
+    const pluginTarget = path.resolve(expandHome(entry.plugin_target || path.join(codexPluginRoot, "agent-wallet")));
+    const marketplacePath = path.resolve(expandHome(entry.marketplace_path || codexMarketplacePath));
+    const link = repairRuntimeSymlink(
+      "codex",
+      pluginTarget,
+      path.join(currentRuntimePath, "codex", "plugins", "agent-wallet"),
+      env,
+      { allowExternal: true },
+    );
+    if (!link.ok) return link;
+    const marketplace = ensureCodexMarketplaceEntry({ marketplacePath, pluginName: "agent-wallet" });
+    const registration = runHostRefresh(
+      "codex",
+      ["plugin", "add", `agent-wallet@${marketplace.marketplace_name}`],
+      { ...env, CODEX_HOME: entry.codex_home || codexHome },
+    );
+    registry.record("codex", {
+      ...entry,
+      plugin_target: pluginTarget,
+      marketplace_path: marketplacePath,
+      marketplace_name: marketplace.marketplace_name,
+      registration_ok: registration.ok,
+      restart_required: true,
+    });
+    return { ...link, ok: link.ok && registration.ok, registration, restart_required: true };
+  }
+
+  function refreshClaudeCode() {
+    const entry = registry.managed("claude-code") || adoptClaudeCode();
+    if (!entry) return null;
+    const marketplaceDir = path.resolve(expandHome(entry.marketplace_dir || claudeMarketplaceDir));
+    const cacheRoot = path.resolve(
+      expandHome(entry.cache_root || env.AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT || "~/.claude/plugins/cache"),
+    );
+    const pluginTarget = path.resolve(expandHome(entry.plugin_target || path.join(marketplaceDir, "plugins", "agent-wallet")));
+    const link = repairRuntimeSymlink(
+      "claude-code",
+      pluginTarget,
+      path.join(currentRuntimePath, "claude-code", "plugins", "agent-wallet"),
+      env,
+      { allowExternal: true },
+    );
+    if (!link.ok) return link;
+    ensureClaudeCodeMarketplace(
+      marketplaceDir,
+      path.join(currentRuntimePath, "claude-code", "plugins", "agent-wallet"),
+      true,
+    );
+    const marketplaceAdd = runHostRefresh(
+      "claude",
+      ["plugin", "marketplace", "add", marketplaceDir, "--scope", "user"],
+    );
+    const registration = marketplaceAdd.ok
+      ? runHostRefresh(
+          "claude",
+          ["plugin", "install", `agent-wallet@${claudeMarketplaceName}`, "--scope", "user"],
+        )
+      : { attempted: false, ok: false, error: "marketplace refresh failed", fix: marketplaceAdd.fix };
+    const cachePins = pinClaudeCacheCopies({ ...env, AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT: cacheRoot });
+    registry.record("claude-code", {
+      ...entry,
+      marketplace_dir: marketplaceDir,
+      plugin_target: pluginTarget,
+      cache_root: cacheRoot,
+      registration_ok: registration.ok,
+      restart_required: true,
+    });
+    return {
+      ...link,
+      ok: link.ok && marketplaceAdd.ok && registration.ok,
+      marketplace_add: marketplaceAdd,
+      registration,
+      cache_pins: cachePins,
+      restart_required: true,
+    };
+  }
+
+  function refreshAll() {
+    return registry.refreshAll({
+      openclaw: refreshOpenclaw,
+      hermes: refreshHermes,
+      codex: refreshCodex,
+      "claude-code": refreshClaudeCode,
+    });
+  }
+
+  return { refreshAll };
 }

--- a/bin/lib/integrations.mjs
+++ b/bin/lib/integrations.mjs
@@ -26,16 +26,50 @@ function writeJsonAtomic(pathname, value) {
 export function createIntegrationManager({ runtimeBase, packageVersion, activeVersion }) {
   const registryPath = path.join(runtimeBase, "integrations.json");
 
+  function emptyRegistry(error = "") {
+    return {
+      schema_version: 1,
+      integrations: {},
+      ...(error ? { registry_error: error } : {}),
+    };
+  }
+
   function readRegistry() {
-    const payload = readJson(registryPath);
-    if (!payload || payload.schema_version !== 1 || typeof payload.integrations !== "object") {
-      return { schema_version: 1, integrations: {} };
+    let payload;
+    try {
+      payload = readJson(registryPath);
+    } catch (error) {
+      return emptyRegistry(`integration registry is unreadable: ${error.message}`);
+    }
+    if (!payload) return emptyRegistry();
+    if (
+      payload.schema_version !== 1 ||
+      !payload.integrations ||
+      typeof payload.integrations !== "object" ||
+      Array.isArray(payload.integrations)
+    ) {
+      return emptyRegistry("integration registry schema is invalid");
     }
     return payload;
   }
 
+  function quarantineCorruptRegistry(registry) {
+    if (!registry.registry_error || !fs.existsSync(registryPath)) return null;
+    let backup = `${registryPath}.corrupt-${Date.now()}`;
+    let suffix = 2;
+    while (fs.existsSync(backup)) {
+      backup = `${registryPath}.corrupt-${Date.now()}-${suffix}`;
+      suffix += 1;
+    }
+    fs.renameSync(registryPath, backup);
+    return backup;
+  }
+
   function record(name, details = {}) {
-    const registry = readRegistry();
+    let registry = readRegistry();
+    const corruptBackup = quarantineCorruptRegistry(registry);
+    if (registry.registry_error) registry = emptyRegistry();
+    if (corruptBackup) registry.recovered_corrupt_registry = path.basename(corruptBackup);
     registry.integrations[name] = {
       ...details,
       managed: true,
@@ -54,7 +88,8 @@ export function createIntegrationManager({ runtimeBase, packageVersion, activeVe
 
   function status() {
     const active = activeVersion();
-    const integrations = Object.entries(readRegistry().integrations)
+    const registry = readRegistry();
+    const managedIntegrations = Object.entries(registry.integrations)
       .filter(([, entry]) => entry?.managed === true)
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([name, entry]) => {
@@ -69,7 +104,13 @@ export function createIntegrationManager({ runtimeBase, packageVersion, activeVe
           restart_required: Boolean(entry.restart_required),
         };
       });
-    return { in_sync: integrations.every((entry) => entry.in_sync), integrations };
+    return {
+      in_sync: !registry.registry_error && managedIntegrations.every((entry) => entry.in_sync),
+      registry_ok: !registry.registry_error,
+      registry_error: registry.registry_error || "",
+      recovered_corrupt_registry: registry.recovered_corrupt_registry || null,
+      integrations: managedIntegrations,
+    };
   }
 
   function safelyRefresh(name, callback) {

--- a/bin/lib/integrations.mjs
+++ b/bin/lib/integrations.mjs
@@ -123,10 +123,26 @@ export function createHostIntegrationManager({
   ensureClaudeCodeMarketplace,
   pinClaudeCacheCopies,
 }) {
+  const runtimeBase = path.dirname(currentRuntimePath);
+
+  function runtimeOwnedTarget(target) {
+    const relative = path.relative(runtimeBase, path.resolve(target));
+    return relative === "" || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+  }
+
+  function symlinkTarget(linkPath) {
+    try {
+      if (!fs.lstatSync(linkPath).isSymbolicLink()) return null;
+      return path.resolve(path.dirname(linkPath), fs.readlinkSync(linkPath));
+    } catch {
+      return null;
+    }
+  }
+
   function symlinkManifestMatches(linkPath, manifestRelativePath, expectedName) {
     try {
-      if (!fs.lstatSync(linkPath).isSymbolicLink()) return false;
-      const target = path.resolve(path.dirname(linkPath), fs.readlinkSync(linkPath));
+      const target = symlinkTarget(linkPath);
+      if (!target || !runtimeOwnedTarget(target)) return false;
       return readJson(path.join(target, manifestRelativePath))?.name === expectedName;
     } catch {
       return false;
@@ -135,13 +151,8 @@ export function createHostIntegrationManager({
 
   function adoptHermes() {
     const pluginTarget = path.join(hermesHome, "plugins", "agent_wallet");
-    let target;
-    try {
-      if (!fs.lstatSync(pluginTarget).isSymbolicLink()) return null;
-      target = path.resolve(path.dirname(pluginTarget), fs.readlinkSync(pluginTarget));
-    } catch {
-      return null;
-    }
+    const target = symlinkTarget(pluginTarget);
+    if (!target || !runtimeOwnedTarget(target)) return null;
     let manifest = "";
     try {
       manifest = fs.readFileSync(path.join(target, "plugin.yaml"), "utf8");

--- a/bin/lib/integrations.mjs
+++ b/bin/lib/integrations.mjs
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(pathname) {
+  try {
+    return JSON.parse(fs.readFileSync(pathname, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function writeJsonAtomic(pathname, value) {
+  fs.mkdirSync(path.dirname(pathname), { recursive: true });
+  const temporary = `${pathname}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporary, pathname);
+    fs.chmodSync(pathname, 0o600);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export function createIntegrationManager({ runtimeBase, packageVersion, activeVersion }) {
+  const registryPath = path.join(runtimeBase, "integrations.json");
+
+  function readRegistry() {
+    const payload = readJson(registryPath);
+    if (!payload || payload.schema_version !== 1 || typeof payload.integrations !== "object") {
+      return { schema_version: 1, integrations: {} };
+    }
+    return payload;
+  }
+
+  function record(name, details = {}) {
+    const registry = readRegistry();
+    registry.integrations[name] = {
+      ...details,
+      managed: true,
+      installed_version: packageVersion,
+      updated_at: new Date().toISOString(),
+    };
+    registry.updated_at = new Date().toISOString();
+    writeJsonAtomic(registryPath, registry);
+    return registry.integrations[name];
+  }
+
+  function managed(name) {
+    const entry = readRegistry().integrations[name];
+    return entry?.managed === true ? entry : null;
+  }
+
+  function status() {
+    const active = activeVersion();
+    const integrations = Object.entries(readRegistry().integrations)
+      .filter(([, entry]) => entry?.managed === true)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, entry]) => {
+        const versionInSync = active === null || entry.installed_version === active;
+        const registrationOk = entry.registration_ok !== false;
+        return {
+          name,
+          installed_version: entry.installed_version || null,
+          active_version: active,
+          in_sync: versionInSync && registrationOk,
+          registration_ok: registrationOk,
+          restart_required: Boolean(entry.restart_required),
+        };
+      });
+    return { in_sync: integrations.every((entry) => entry.in_sync), integrations };
+  }
+
+  function safelyRefresh(name, callback) {
+    try {
+      return callback();
+    } catch (error) {
+      const fix = name === "global-cli"
+        ? "Re-run: wallet update --yes"
+        : name === "openclaw"
+          ? "Re-run: wallet install --yes"
+          : `Re-run: wallet ${name} install --yes`;
+      return {
+        name,
+        attempted: true,
+        ok: false,
+        repaired: false,
+        error: error?.message || String(error),
+        restart_required: false,
+        fix,
+      };
+    }
+  }
+
+  function refreshAll(refreshers) {
+    return Object.entries(refreshers)
+      .map(([name, callback]) => safelyRefresh(name, callback))
+      .filter(Boolean);
+  }
+
+  return { registryPath, readRegistry, record, managed, status, safelyRefresh, refreshAll };
+}

--- a/bin/lib/update-transaction.mjs
+++ b/bin/lib/update-transaction.mjs
@@ -1,0 +1,235 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function readJson(pathname) {
+  try {
+    return JSON.parse(fs.readFileSync(pathname, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function writeJsonAtomic(pathname, value) {
+  fs.mkdirSync(path.dirname(pathname), { recursive: true });
+  const temporary = `${pathname}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporary, pathname);
+    fs.chmodSync(pathname, 0o600);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+function uniquePath(target) {
+  if (!fs.existsSync(target)) return target;
+  let counter = 2;
+  while (fs.existsSync(`${target}-${counter}`)) counter += 1;
+  return `${target}-${counter}`;
+}
+
+function readLink(target) {
+  try {
+    return fs.lstatSync(target).isSymbolicLink() ? fs.readlinkSync(target) : null;
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function processIsRunning(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+export function createUpdateTransactionManager({ runtimeBase, packageVersion, env = process.env }) {
+  const base = path.resolve(runtimeBase);
+  const journalPath = path.join(base, "update-journal.json");
+  const lockPath = path.join(base, "update.lock");
+
+  function readJournal() {
+    try {
+      return readJson(journalPath);
+    } catch (error) {
+      return { schema_version: 1, state: "corrupt", error: error.message };
+    }
+  }
+
+  function writeJournal(state, details = {}) {
+    writeJsonAtomic(journalPath, {
+      ...details,
+      schema_version: 2,
+      state,
+      version: details.version || packageVersion,
+      updated_at: new Date().toISOString(),
+    });
+  }
+
+  function runtimeOwned(candidate) {
+    if (!candidate) return false;
+    const relative = path.relative(base, path.resolve(candidate));
+    return relative !== "" && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  }
+
+  function interruptedPath(version) {
+    return uniquePath(
+      path.join(base, "releases", `.interrupted-${version || "unknown"}-${Date.now()}`),
+    );
+  }
+
+  function acquireLock(allowStaleRetry = true) {
+    const ownerPath = path.join(lockPath, "owner.json");
+    const token = crypto.randomUUID();
+    fs.mkdirSync(base, { recursive: true });
+    try {
+      fs.mkdirSync(lockPath);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      let owner = null;
+      try {
+        owner = readJson(ownerPath);
+      } catch {
+        // An unreadable lock is not safe to steal automatically.
+      }
+      const stale = owner?.hostname === os.hostname() && !processIsRunning(Number(owner.pid));
+      if (stale && allowStaleRetry) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        return acquireLock(false);
+      }
+      return {
+        ok: false,
+        path: lockPath,
+        owner: owner ? { pid: owner.pid, hostname: owner.hostname, started_at: owner.started_at } : null,
+      };
+    }
+    try {
+      writeJsonAtomic(ownerPath, {
+        schema_version: 1,
+        pid: process.pid,
+        hostname: os.hostname(),
+        token,
+        started_at: new Date().toISOString(),
+      });
+    } catch (error) {
+      fs.rmSync(lockPath, { recursive: true, force: true });
+      throw error;
+    }
+    return { ok: true, path: lockPath, owner_path: ownerPath, token };
+  }
+
+  function releaseLock(lock) {
+    if (!lock?.ok) return;
+    try {
+      const owner = readJson(lock.owner_path);
+      if (owner?.token === lock.token) fs.rmSync(lock.path, { recursive: true, force: true });
+    } catch {
+      // Never remove a lock whose ownership can no longer be verified.
+    }
+  }
+
+  function recover() {
+    const journal = readJournal();
+    if (!journal || ["committed", "failed", "recovered"].includes(journal.state)) {
+      return { attempted: false, ok: true, reason: "no interrupted update" };
+    }
+    if (journal.state === "corrupt") {
+      return { attempted: false, ok: false, reason: "update journal is corrupt", error: journal.error };
+    }
+    const paths = [journal.staging_root, journal.release_root, journal.replaced_root].filter(Boolean);
+    if (paths.some((candidate) => !runtimeOwned(candidate))) {
+      return { attempted: false, ok: false, reason: "update journal contains an unsafe path" };
+    }
+    if (journal.state === "committing") {
+      const releaseExists = Boolean(journal.release_root && fs.existsSync(journal.release_root));
+      const replacedExists = Boolean(journal.replaced_root && fs.existsSync(journal.replaced_root));
+      if (!releaseExists && replacedExists) {
+        fs.renameSync(journal.replaced_root, journal.release_root);
+        writeJournal("recovered", { ...journal, action: "restored_replaced_release" });
+        return { attempted: true, ok: true, action: "restored_replaced_release" };
+      }
+      if (releaseExists) {
+        writeJournal("recovered", { ...journal, action: "release_already_present" });
+        return { attempted: true, ok: true, action: "release_already_present" };
+      }
+      return { attempted: true, ok: false, reason: "interrupted commit has no recoverable release" };
+    }
+    if (["preparing", "verified"].includes(journal.state)) {
+      let quarantined = null;
+      if (journal.staging_root && fs.existsSync(journal.staging_root)) {
+        quarantined = interruptedPath(journal.version);
+        fs.renameSync(journal.staging_root, quarantined);
+      }
+      writeJournal("recovered", {
+        ...journal,
+        action: "quarantined_incomplete_staging",
+        quarantined_runtime: quarantined,
+      });
+      return {
+        attempted: true,
+        ok: true,
+        action: "quarantined_incomplete_staging",
+        quarantined_runtime: quarantined,
+      };
+    }
+    return { attempted: false, ok: false, reason: `unsupported update journal state: ${journal.state}` };
+  }
+
+  function status() {
+    const journal = readJournal();
+    const state = journal?.state || null;
+    const currentPath = path.join(base, "current");
+    const currentTarget = readLink(currentPath);
+    const currentResolves = Boolean(
+      currentTarget && fs.existsSync(path.resolve(path.dirname(currentPath), currentTarget)),
+    );
+    let lockOwner = null;
+    try {
+      const owner = readJson(path.join(lockPath, "owner.json"));
+      if (owner) {
+        lockOwner = {
+          pid: owner.pid,
+          hostname: owner.hostname,
+          started_at: owner.started_at,
+          active: owner.hostname === os.hostname() ? processIsRunning(Number(owner.pid)) : null,
+        };
+      }
+    } catch {
+      if (fs.existsSync(lockPath)) lockOwner = { unreadable: true };
+    }
+    return {
+      journal_schema_version: journal?.schema_version || null,
+      state,
+      journal_ok: state !== "corrupt",
+      needs_recovery: Boolean(state && !["committed", "failed", "recovered"].includes(state)),
+      current_resolves: currentTarget ? currentResolves : null,
+      lock: lockOwner,
+    };
+  }
+
+  function holdLockForTest() {
+    const milliseconds = Number.parseInt(String(env.AGENT_WALLET_TEST_HOLD_LOCK_MS || ""), 10);
+    if (Number.isFinite(milliseconds) && milliseconds > 0) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+    }
+  }
+
+  return {
+    journalPath,
+    lockPath,
+    readJournal,
+    writeJournal,
+    acquireLock,
+    releaseLock,
+    recover,
+    status,
+    holdLockForTest,
+  };
+}

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createBootKeyManager } from "./lib/boot-key.mjs";
 import { createUpdateTransactionManager } from "./lib/update-transaction.mjs";
 
 const cliPath = fileURLToPath(import.meta.url);
@@ -1040,12 +1041,6 @@ function writeJsonFileAtomic(pathname, value, mode = 0o600) {
   }
 }
 
-function currentBootKey(env = process.env) {
-  const currentRoot = resolvedCurrentRuntimeRoot(env);
-  if (!currentRoot) return "";
-  return readEnvFile(path.join(currentRoot, "agent-wallet", ".env")).AGENT_WALLET_BOOT_KEY || "";
-}
-
 function readTextIfExists(pathname) {
   try {
     return fs.readFileSync(pathname, "utf8");
@@ -1055,131 +1050,36 @@ function readTextIfExists(pathname) {
   }
 }
 
-function writeSecretFile(pathname, value) {
-  fs.mkdirSync(path.dirname(pathname), { recursive: true });
-  fs.writeFileSync(pathname, `${String(value || "").trim()}\n`, { mode: 0o600 });
-  try {
-    fs.chmodSync(pathname, 0o600);
-  } catch {
-    // ignored
-  }
-}
-
-function resolveBootKeyFromFile(env = process.env) {
-  const keyFile = String(env.AGENT_WALLET_BOOT_KEY_FILE || "").trim();
-  if (!keyFile) return "";
-  return readTextIfExists(path.resolve(expandHome(keyFile))).trim();
-}
-
-function defaultBootKeyFile(env = process.env) {
-  return path.join(resolveRuntimeBase(env), "boot-key");
+function bootKeys(env = process.env) {
+  return createBootKeyManager({
+    runtimeBase: resolveRuntimeBase(env),
+    openclawHome: resolveOpenclawHome(env),
+    currentRuntimeRoot: () => resolvedCurrentRuntimeRoot(env),
+    resolveVenvPython,
+    expandHome,
+    bridgeTimeoutMs: positiveIntEnv(
+      "AGENT_WALLET_KEYSTORE_BRIDGE_TIMEOUT_MS",
+      KEYSTORE_BRIDGE_TIMEOUT_MS,
+      env,
+    ),
+    env,
+  });
 }
 
 function ensureBootKeyFile(env = process.env) {
-  const configuredFile = String(env.AGENT_WALLET_BOOT_KEY_FILE || "").trim();
-  const keyFile = configuredFile ? path.resolve(expandHome(configuredFile)) : defaultBootKeyFile(env);
-  const existing = readTextIfExists(keyFile).trim();
-  if (existing) {
-    return { path: keyFile, status: "existing" };
-  }
-  const bootKey = String(env.AGENT_WALLET_BOOT_KEY || "").trim() || resolveBootKeyFromFile(env) || currentBootKey(env);
-  if (!bootKey) {
-    return { path: keyFile, status: "missing" };
-  }
-  writeSecretFile(keyFile, bootKey);
-  return { path: keyFile, status: "created" };
+  return bootKeys(env).ensureFile();
 }
 
-// Read the boot key from the OS keystore via the current runtime's Python
-// (best-effort, "" on any failure). Lets a re-install after the runtime migration
-// — which moves the key into the keystore and deletes every plaintext copy — still
-// resolve the existing boot key instead of refusing to touch sealed secrets.
-function readBootKeyFromKeystore(env = process.env) {
-  const runtimeRoot = resolvedCurrentRuntimeRoot(env);
-  if (!runtimeRoot) return "";
-  const py = resolveVenvPython(runtimeRoot);
-  if (!py) return "";
-  try {
-    const res = spawnSync(
-      py,
-      ["-c", "from agent_wallet.config import read_boot_key_from_keystore as r; print(r())"],
-      {
-        cwd: path.join(runtimeRoot, "agent-wallet"),
-        encoding: "utf8",
-        timeout: positiveIntEnv("AGENT_WALLET_KEYSTORE_BRIDGE_TIMEOUT_MS", KEYSTORE_BRIDGE_TIMEOUT_MS, env),
-        env: { ...env, OPENCLAW_HOME: resolveOpenclawHome(env) },
-      },
-    );
-    if ((res.status ?? 1) !== 0) return "";
-    return String(res.stdout || "").trim();
-  } catch {
-    return "";
-  }
-}
-
-// New runtimes own boot-key precedence and verify candidates against
-// sealed_keys.json. An import failure means the active runtime predates this
-// bridge, so callers may use the legacy JS fallback below.
 function readBootKeyFromRuntimeResolver(env = process.env) {
-  const runtimeRoot = resolvedCurrentRuntimeRoot(env);
-  if (!runtimeRoot) return { supported: false, key: "" };
-  const py = resolveVenvPython(runtimeRoot);
-  if (!py) return { supported: false, key: "" };
-  try {
-    const res = spawnSync(
-      py,
-      ["-c", "from agent_wallet.config import resolve_boot_key_for_installer as r; print(r())"],
-      {
-        cwd: path.join(runtimeRoot, "agent-wallet"),
-        encoding: "utf8",
-        timeout: positiveIntEnv("AGENT_WALLET_KEYSTORE_BRIDGE_TIMEOUT_MS", KEYSTORE_BRIDGE_TIMEOUT_MS, env),
-        env: { ...env, OPENCLAW_HOME: resolveOpenclawHome(env) },
-      },
-    );
-    if ((res.status ?? 1) !== 0) return { supported: false, key: "" };
-    return { supported: true, key: String(res.stdout || "").trim() };
-  } catch {
-    return { supported: false, key: "" };
-  }
+  return bootKeys(env).resolveFromRuntime();
 }
 
 function resolveLegacyInstallerBootKey(env = process.env) {
-  for (const [source, key] of [
-    ["legacy_keystore", readBootKeyFromKeystore(env)],
-    ["current_runtime_env", currentBootKey(env)],
-    ["configured_file", resolveBootKeyFromFile(env)],
-    ["default_file", readTextIfExists(defaultBootKeyFile(env)).trim()],
-  ]) {
-    if (key) return { key, source };
-  }
-  return { key: "", source: "none" };
+  return bootKeys(env).resolveLegacy();
 }
 
-// Provision the boot key into the OS keystore via the freshly installed runtime's
-// Python. Returns true only when the import stored AND verified the key, so the
-// caller may safely drop the plaintext .env copy. Best-effort: false on any failure
-// (e.g. no usable keystore), in which case the caller keeps the legacy .env write.
 function provisionBootKeyToKeystore(releaseRoot, env, bootKey) {
-  const key = String(bootKey || "").trim();
-  if (!key) return false;
-  const py = resolveVenvPython(releaseRoot);
-  if (!py) return false;
-  try {
-    const res = spawnSync(
-      py,
-      ["-m", "agent_wallet.openclaw_cli", "boot-key-import", "--key-stdin"],
-      {
-        cwd: path.join(releaseRoot, "agent-wallet"),
-        input: key,
-        encoding: "utf8",
-        timeout: positiveIntEnv("AGENT_WALLET_KEYSTORE_BRIDGE_TIMEOUT_MS", KEYSTORE_BRIDGE_TIMEOUT_MS, env),
-        env: { ...env, OPENCLAW_HOME: resolveOpenclawHome(env) },
-      },
-    );
-    return (res.status ?? 1) === 0;
-  } catch {
-    return false;
-  }
+  return bootKeys(env).provision(releaseRoot, bootKey);
 }
 
 function resolveVenvPython(releaseRoot) {
@@ -1258,36 +1158,7 @@ function verifyRuntime(releaseRoot, env = process.env) {
 }
 
 function verifyBootKeyWithRuntime(releaseRoot, env = process.env) {
-  const sealedPath = path.join(resolveOpenclawHome(env), "sealed_keys.json");
-  if (!fs.existsSync(sealedPath)) return { ok: true, required: false };
-  const key = String(env.AGENT_WALLET_BOOT_KEY || "").trim();
-  if (!key) return { ok: false, required: true, error: "no verified boot key is available" };
-  const python =
-    env.AGENT_WALLET_PYTHON ||
-    env.OPENCLAW_AGENT_WALLET_PYTHON ||
-    resolveVenvPython(releaseRoot);
-  if (!python) {
-    if (String(env.AGENT_WALLET_VERIFY_DISABLE || "") === "1") {
-      return { ok: true, required: true, skipped: true };
-    }
-    return { ok: false, required: true, error: "staged Python runtime is unavailable" };
-  }
-  const result = spawnSync(
-    python,
-    [
-      "-c",
-      "from agent_wallet.sealed_keys import unseal_keys; import os; unseal_keys(os.environ['AGENT_WALLET_BOOT_KEY']); print('ok')",
-    ],
-    {
-      cwd: path.join(releaseRoot, "agent-wallet"),
-      encoding: "utf8",
-      timeout: positiveIntEnv("AGENT_WALLET_KEYSTORE_BRIDGE_TIMEOUT_MS", KEYSTORE_BRIDGE_TIMEOUT_MS, env),
-      env: { ...env, OPENCLAW_HOME: resolveOpenclawHome(env) },
-    },
-  );
-  return result.status === 0
-    ? { ok: true, required: true }
-    : { ok: false, required: true, error: "selected boot key does not unlock sealed wallet state" };
+  return bootKeys(env).verifyWithRuntime(releaseRoot);
 }
 
 function resolveEditorServerChecks(env = process.env) {

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createUpdateTransactionManager } from "./lib/update-transaction.mjs";
 
 const cliPath = fileURLToPath(import.meta.url);
 const packageRoot = path.resolve(path.dirname(cliPath), "..");
@@ -388,100 +389,31 @@ function stagingRootFor(version, env = process.env) {
   );
 }
 
-function updateJournalPath(env = process.env) {
-  return path.join(resolveRuntimeBase(env), "update-journal.json");
+function updateTransactions(env = process.env) {
+  return createUpdateTransactionManager({
+    runtimeBase: resolveRuntimeBase(env),
+    packageVersion,
+    env,
+  });
 }
 
-function updateLockPath(env = process.env) {
-  return path.join(resolveRuntimeBase(env), "update.lock");
-}
-
-function processIsRunning(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code !== "ESRCH";
-  }
-}
-
-function acquireUpdateLock(env = process.env, allowStaleRetry = true) {
-  const lockPath = updateLockPath(env);
-  const ownerPath = path.join(lockPath, "owner.json");
-  const token = crypto.randomUUID();
-  fs.mkdirSync(resolveRuntimeBase(env), { recursive: true });
-  try {
-    fs.mkdirSync(lockPath);
-  } catch (error) {
-    if (error?.code !== "EEXIST") throw error;
-    let owner = null;
-    try {
-      owner = readJsonFile(ownerPath);
-    } catch {
-      // An unreadable lock is not safe to steal automatically.
-    }
-    const stale = owner?.hostname === os.hostname() && !processIsRunning(Number(owner.pid));
-    if (stale && allowStaleRetry) {
-      fs.rmSync(lockPath, { recursive: true, force: true });
-      return acquireUpdateLock(env, false);
-    }
-    return {
-      ok: false,
-      path: lockPath,
-      owner: owner ? { pid: owner.pid, hostname: owner.hostname, started_at: owner.started_at } : null,
-    };
-  }
-  try {
-    writeJsonFileAtomic(ownerPath, {
-      schema_version: 1,
-      pid: process.pid,
-      hostname: os.hostname(),
-      token,
-      started_at: new Date().toISOString(),
-    });
-  } catch (error) {
-    fs.rmSync(lockPath, { recursive: true, force: true });
-    throw error;
-  }
-  return { ok: true, path: lockPath, owner_path: ownerPath, token };
+function acquireUpdateLock(env = process.env) {
+  return updateTransactions(env).acquireLock();
 }
 
 function releaseUpdateLock(lock) {
-  if (!lock?.ok) return;
-  try {
-    const owner = readJsonFile(lock.owner_path);
-    if (owner?.token === lock.token) fs.rmSync(lock.path, { recursive: true, force: true });
-  } catch {
-    // Never remove a lock whose ownership can no longer be verified.
-  }
+  return createUpdateTransactionManager({
+    runtimeBase: path.dirname(lock.path),
+    packageVersion,
+  }).releaseLock(lock);
 }
 
 function holdUpdateLockForTest(env = process.env) {
-  const milliseconds = Number.parseInt(String(env.AGENT_WALLET_TEST_HOLD_LOCK_MS || ""), 10);
-  if (!Number.isFinite(milliseconds) || milliseconds <= 0) return;
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+  updateTransactions(env).holdLockForTest();
 }
 
 function readUpdateJournal(env = process.env) {
-  try {
-    return readJsonFile(updateJournalPath(env));
-  } catch (error) {
-    return { schema_version: 1, state: "corrupt", error: error.message };
-  }
-}
-
-function runtimeOwnedPath(candidate, env = process.env) {
-  if (!candidate) return false;
-  const runtimeBase = path.resolve(resolveRuntimeBase(env));
-  const relative = path.relative(runtimeBase, path.resolve(candidate));
-  return relative !== "" && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
-}
-
-function interruptedRuntimePath(version, env = process.env) {
-  return uniquePathWithSuffix(
-    path.join(resolveRuntimeBase(env), "releases", `.interrupted-${version || "unknown"}-${Date.now()}`),
-  );
+  return updateTransactions(env).readJournal();
 }
 
 function integrationRegistryPath(env = process.env) {
@@ -539,99 +471,15 @@ function integrationSyncStatus(env = process.env) {
 }
 
 function writeUpdateJournal(state, details = {}, env = process.env) {
-  writeJsonFileAtomic(updateJournalPath(env), {
-    ...details,
-    schema_version: 2,
-    state,
-    version: details.version || packageVersion,
-    updated_at: new Date().toISOString(),
-  });
+  updateTransactions(env).writeJournal(state, details);
 }
 
 function recoverInterruptedUpdate(env = process.env) {
-  const journal = readUpdateJournal(env);
-  if (!journal || ["committed", "failed", "recovered"].includes(journal.state)) {
-    return { attempted: false, ok: true, reason: "no interrupted update" };
-  }
-  if (journal.state === "corrupt") {
-    return { attempted: false, ok: false, reason: "update journal is corrupt", error: journal.error };
-  }
-  const paths = [journal.staging_root, journal.release_root, journal.replaced_root].filter(Boolean);
-  if (paths.some((candidate) => !runtimeOwnedPath(candidate, env))) {
-    return { attempted: false, ok: false, reason: "update journal contains an unsafe path" };
-  }
-
-  if (journal.state === "committing") {
-    const releaseExists = Boolean(journal.release_root && fs.existsSync(journal.release_root));
-    const replacedExists = Boolean(journal.replaced_root && fs.existsSync(journal.replaced_root));
-    if (!releaseExists && replacedExists) {
-      fs.renameSync(journal.replaced_root, journal.release_root);
-      writeUpdateJournal(
-        "recovered",
-        { ...journal, state: undefined, action: "restored_replaced_release" },
-        env,
-      );
-      return { attempted: true, ok: true, action: "restored_replaced_release" };
-    }
-    if (releaseExists) {
-      writeUpdateJournal(
-        "recovered",
-        { ...journal, state: undefined, action: "release_already_present" },
-        env,
-      );
-      return { attempted: true, ok: true, action: "release_already_present" };
-    }
-    return { attempted: true, ok: false, reason: "interrupted commit has no recoverable release" };
-  }
-
-  if (["preparing", "verified"].includes(journal.state)) {
-    let quarantined = null;
-    if (journal.staging_root && fs.existsSync(journal.staging_root)) {
-      quarantined = interruptedRuntimePath(journal.version, env);
-      fs.renameSync(journal.staging_root, quarantined);
-    }
-    writeUpdateJournal(
-      "recovered",
-      { ...journal, state: undefined, action: "quarantined_incomplete_staging", quarantined_runtime: quarantined },
-      env,
-    );
-    return { attempted: true, ok: true, action: "quarantined_incomplete_staging", quarantined_runtime: quarantined };
-  }
-  return { attempted: false, ok: false, reason: `unsupported update journal state: ${journal.state}` };
+  return updateTransactions(env).recover();
 }
 
 function updateRecoveryStatus(env = process.env) {
-  const journal = readUpdateJournal(env);
-  const state = journal?.state || null;
-  const currentPath = currentRuntimePath(env);
-  const currentTarget = readLinkOrNull(currentPath);
-  const currentResolves = Boolean(currentTarget && fs.existsSync(path.resolve(path.dirname(currentPath), currentTarget)));
-  let lockOwner = null;
-  try {
-    const owner = readJsonFile(path.join(updateLockPath(env), "owner.json"));
-    if (owner) {
-      lockOwner = {
-        pid: owner.pid,
-        hostname: owner.hostname,
-        started_at: owner.started_at,
-        active: owner.hostname === os.hostname() ? processIsRunning(Number(owner.pid)) : null,
-      };
-    }
-  } catch {
-    // Report an unreadable lock as present without trusting its contents.
-    if (fs.existsSync(updateLockPath(env))) lockOwner = { unreadable: true };
-  }
-  const needsRecovery = Boolean(
-    state && !["committed", "failed", "recovered"].includes(state),
-  );
-  return {
-    journal_schema_version: journal?.schema_version || null,
-    state,
-    journal_ok: state !== "corrupt",
-    needs_recovery: needsRecovery,
-    current_resolves: currentTarget ? currentResolves : null,
-    lock: lockOwner,
-  };
+  return updateTransactions(env).status();
 }
 
 function writeReleaseState(runtimeRoot, state, details = {}) {

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createBootKeyManager } from "./lib/boot-key.mjs";
-import { createIntegrationManager } from "./lib/integrations.mjs";
+import { createHostIntegrationManager, createIntegrationManager } from "./lib/integrations.mjs";
 import { createUpdateTransactionManager } from "./lib/update-transaction.mjs";
 
 const cliPath = fileURLToPath(import.meta.url);
@@ -430,12 +430,32 @@ function recordManagedIntegration(name, details = {}, env = process.env) {
   return integrations(env).record(name, details);
 }
 
-function managedIntegration(name, env = process.env) {
-  return integrations(env).managed(name);
-}
-
 function integrationSyncStatus(env = process.env) {
   return integrations(env).status();
+}
+
+function hostIntegrations(env = process.env) {
+  return createHostIntegrationManager({
+    env,
+    packageRoot,
+    registry: integrations(env),
+    currentRuntimePath: currentRuntimePath(env),
+    openclawHome: resolveOpenclawHome(env),
+    hermesHome: resolveHermesHome(env),
+    codexHome: resolveCodexHome(env),
+    codexPluginRoot: resolveCodexPluginInstallRoot(env),
+    codexMarketplacePath: resolveCodexMarketplacePath(env),
+    claudeMarketplaceDir: resolveClaudeCodeMarketplaceDir(env),
+    claudeMarketplaceName: CLAUDE_CODE_MARKETPLACE_NAME,
+    expandHome,
+    resolveVenvPython,
+    commandPath,
+    repairRuntimeSymlink,
+    repairHermesEnv,
+    ensureCodexMarketplaceEntry,
+    ensureClaudeCodeMarketplace,
+    pinClaudeCacheCopies,
+  });
 }
 
 function writeUpdateJournal(state, details = {}, env = process.env) {
@@ -1005,15 +1025,6 @@ function writeJsonFileAtomic(pathname, value, mode = 0o600) {
     } catch {
       // ignored
     }
-  }
-}
-
-function readTextIfExists(pathname) {
-  try {
-    return fs.readFileSync(pathname, "utf8");
-  } catch (error) {
-    if (error?.code === "ENOENT") return "";
-    throw error;
   }
 }
 
@@ -2510,189 +2521,6 @@ function repairHermesEnv(envPath, env = process.env) {
   return repaired;
 }
 
-function legacyHermesIntegration(env = process.env) {
-  const hermesHome = resolveHermesHome(env);
-  const pluginTarget = path.join(hermesHome, "plugins", "agent_wallet");
-  let target;
-  try {
-    if (!fs.lstatSync(pluginTarget).isSymbolicLink()) return null;
-    target = path.resolve(path.dirname(pluginTarget), fs.readlinkSync(pluginTarget));
-  } catch {
-    return null;
-  }
-  const manifest = readTextIfExists(path.join(target, "plugin.yaml"));
-  if (!/^name:\s*agent[-_]wallet\s*$/m.test(manifest)) return null;
-  return recordManagedIntegration(
-    "hermes",
-    {
-      hermes_home: hermesHome,
-      plugin_target: pluginTarget,
-      env_path: path.join(hermesHome, ".env"),
-      adopted_legacy_install: true,
-    },
-    env,
-  );
-}
-
-function repairOpenclawIntegration(env = process.env) {
-  const entry = managedIntegration("openclaw", env);
-  if (!entry) {
-    return { name: "openclaw", attempted: false, ok: true, repaired: false, reason: "not managed" };
-  }
-  const configPath = path.resolve(
-    expandHome(entry.config_path || path.join(resolveOpenclawHome(env), "openclaw.json")),
-  );
-  let config;
-  try {
-    config = readJsonFile(configPath);
-  } catch (error) {
-    return { name: "openclaw", attempted: true, ok: false, repaired: false, error: error.message };
-  }
-  if (!config || typeof config !== "object") {
-    return { name: "openclaw", attempted: true, ok: false, repaired: false, error: `missing ${configPath}` };
-  }
-
-  const currentRoot = currentRuntimePath(env);
-  const extensionPath = path.join(currentRoot, ".openclaw", "extensions", "agent-wallet");
-  const packageRootPath = path.join(currentRoot, "agent-wallet");
-  const pythonBin = resolveVenvPython(currentRoot);
-  const plugins = config.plugins && typeof config.plugins === "object" ? config.plugins : (config.plugins = {});
-  const load = plugins.load && typeof plugins.load === "object" ? plugins.load : (plugins.load = {});
-  const paths = Array.isArray(load.paths) ? load.paths : [];
-  load.paths = [
-    ...paths.filter((item) => {
-      const value = String(item || "");
-      return !value.replaceAll("\\", "/").endsWith("/.openclaw/extensions/agent-wallet");
-    }),
-    extensionPath,
-  ];
-  const entries = plugins.entries && typeof plugins.entries === "object" ? plugins.entries : (plugins.entries = {});
-  const walletEntry = entries["agent-wallet"];
-  if (!walletEntry || typeof walletEntry !== "object") {
-    return {
-      name: "openclaw",
-      attempted: false,
-      ok: true,
-      repaired: false,
-      reason: "plugin entry not configured",
-    };
-  }
-  walletEntry.enabled = true;
-  walletEntry.config = walletEntry.config && typeof walletEntry.config === "object" ? walletEntry.config : {};
-  walletEntry.config.packageRoot = packageRootPath;
-  if (pythonBin) walletEntry.config.pythonBin = pythonBin;
-  writeJsonFileAtomic(configPath, config);
-  recordManagedIntegration(
-    "openclaw",
-    {
-      config_path: configPath,
-      extension_path: extensionPath,
-      package_root: packageRootPath,
-      restart_required: true,
-    },
-    env,
-  );
-  return {
-    name: "openclaw",
-    attempted: true,
-    ok: true,
-    repaired: true,
-    config_path: configPath,
-    restart_required: true,
-  };
-}
-
-function symlinkManifestMatches(linkPath, manifestRelativePath, expectedName) {
-  let target;
-  try {
-    if (!fs.lstatSync(linkPath).isSymbolicLink()) return false;
-    target = path.resolve(path.dirname(linkPath), fs.readlinkSync(linkPath));
-  } catch {
-    return false;
-  }
-  try {
-    const manifest = readJsonFile(path.join(target, manifestRelativePath));
-    return manifest && manifest.name === expectedName;
-  } catch {
-    return false;
-  }
-}
-
-function legacyCodexIntegration(env = process.env) {
-  const marketplacePath = resolveCodexMarketplacePath(env);
-  let marketplace;
-  try {
-    marketplace = readJsonFile(marketplacePath);
-  } catch {
-    return null;
-  }
-  const pluginTarget = path.join(resolveCodexPluginInstallRoot(env), "agent-wallet");
-  const registered = Array.isArray(marketplace?.plugins) && marketplace.plugins.some(
-    (item) => item?.name === "agent-wallet" && item?.source?.source === "local",
-  );
-  if (!registered || !symlinkManifestMatches(pluginTarget, ".codex-plugin/plugin.json", "agent-wallet")) {
-    return null;
-  }
-  return recordManagedIntegration(
-    "codex",
-    {
-      codex_home: resolveCodexHome(env),
-      plugin_target: pluginTarget,
-      marketplace_path: marketplacePath,
-      marketplace_name: String(marketplace.name || "local"),
-      adopted_legacy_install: true,
-    },
-    env,
-  );
-}
-
-function legacyClaudeCodeIntegration(env = process.env) {
-  const marketplaceDir = resolveClaudeCodeMarketplaceDir(env);
-  let manifest;
-  try {
-    manifest = readJsonFile(path.join(marketplaceDir, ".claude-plugin", "marketplace.json"));
-  } catch {
-    return null;
-  }
-  const pluginTarget = path.join(marketplaceDir, "plugins", "agent-wallet");
-  const registered = manifest?.name === CLAUDE_CODE_MARKETPLACE_NAME &&
-    Array.isArray(manifest.plugins) && manifest.plugins.some((item) => item?.name === "agent-wallet");
-  if (!registered || !symlinkManifestMatches(pluginTarget, ".claude-plugin/plugin.json", "agent-wallet")) {
-    return null;
-  }
-  return recordManagedIntegration(
-    "claude-code",
-    {
-      marketplace_dir: marketplaceDir,
-      plugin_target: pluginTarget,
-      cache_root: path.resolve(
-        expandHome(env.AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT || "~/.claude/plugins/cache"),
-      ),
-      adopted_legacy_install: true,
-    },
-    env,
-  );
-}
-
-function runHostRefresh(command, args, env = process.env) {
-  const binary = commandPath(command);
-  if (!binary) {
-    return {
-      attempted: false,
-      ok: false,
-      error: `${command} CLI not found`,
-      fix: args.join(" "),
-    };
-  }
-  const result = spawnSync(binary, args, { cwd: packageRoot, encoding: "utf8", env });
-  return {
-    attempted: true,
-    ok: result.status === 0,
-    error: result.status === 0 ? "" : (result.stderr || result.stdout || "").trim(),
-    fix: result.status === 0 ? "" : `${command} ${args.join(" ")}`,
-  };
-}
-
 function globalNpmPackageInfo(env = process.env) {
   const npmBin = commandPath("npm");
   if (!npmBin) return null;
@@ -2744,154 +2572,12 @@ function refreshGlobalCliIfNeeded(env = process.env) {
   };
 }
 
-function refreshCodexIntegration(entry, env = process.env) {
-  const pluginTarget = path.resolve(
-    expandHome(entry.plugin_target || path.join(resolveCodexPluginInstallRoot(env), "agent-wallet")),
-  );
-  const marketplacePath = path.resolve(
-    expandHome(entry.marketplace_path || resolveCodexMarketplacePath(env)),
-  );
-  const link = repairRuntimeSymlink(
-    "codex",
-    pluginTarget,
-    path.join(currentRuntimePath(env), "codex", "plugins", "agent-wallet"),
-    env,
-    { allowExternal: true },
-  );
-  if (!link.ok) return link;
-  const marketplace = ensureCodexMarketplaceEntry({ marketplacePath, pluginName: "agent-wallet" });
-  const registration = runHostRefresh(
-    "codex",
-    ["plugin", "add", `agent-wallet@${marketplace.marketplace_name}`],
-    { ...env, CODEX_HOME: entry.codex_home || resolveCodexHome(env) },
-  );
-  recordManagedIntegration(
-    "codex",
-    {
-      ...entry,
-      plugin_target: pluginTarget,
-      marketplace_path: marketplacePath,
-      marketplace_name: marketplace.marketplace_name,
-      registration_ok: registration.ok,
-      restart_required: true,
-    },
-    env,
-  );
-  return {
-    ...link,
-    ok: link.ok && registration.ok,
-    registration,
-    restart_required: true,
-  };
-}
-
-function refreshClaudeCodeIntegration(entry, env = process.env) {
-  const marketplaceDir = path.resolve(
-    expandHome(entry.marketplace_dir || resolveClaudeCodeMarketplaceDir(env)),
-  );
-  const cacheRoot = path.resolve(
-    expandHome(entry.cache_root || env.AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT || "~/.claude/plugins/cache"),
-  );
-  const pluginTarget = path.resolve(
-    expandHome(entry.plugin_target || path.join(marketplaceDir, "plugins", "agent-wallet")),
-  );
-  const link = repairRuntimeSymlink(
-    "claude-code",
-    pluginTarget,
-    path.join(currentRuntimePath(env), "claude-code", "plugins", "agent-wallet"),
-    env,
-    { allowExternal: true },
-  );
-  if (!link.ok) return link;
-  ensureClaudeCodeMarketplace(
-    marketplaceDir,
-    path.join(currentRuntimePath(env), "claude-code", "plugins", "agent-wallet"),
-    true,
-  );
-  const marketplaceAdd = runHostRefresh(
-    "claude",
-    ["plugin", "marketplace", "add", marketplaceDir, "--scope", "user"],
-    env,
-  );
-  const registration = marketplaceAdd.ok
-    ? runHostRefresh(
-        "claude",
-        ["plugin", "install", `agent-wallet@${CLAUDE_CODE_MARKETPLACE_NAME}`, "--scope", "user"],
-        env,
-      )
-    : { attempted: false, ok: false, error: "marketplace refresh failed", fix: marketplaceAdd.fix };
-  const cachePins = pinClaudeCacheCopies({
-    ...env,
-    AGENT_WALLET_CLAUDE_CODE_CACHE_ROOT: cacheRoot,
-  });
-  recordManagedIntegration(
-    "claude-code",
-    {
-      ...entry,
-      marketplace_dir: marketplaceDir,
-      plugin_target: pluginTarget,
-      cache_root: cacheRoot,
-      registration_ok: registration.ok,
-      restart_required: true,
-    },
-    env,
-  );
-  return {
-    ...link,
-    ok: link.ok && marketplaceAdd.ok && registration.ok,
-    marketplace_add: marketplaceAdd,
-    registration,
-    cache_pins: cachePins,
-    restart_required: true,
-  };
-}
-
 function safelyRefreshIntegration(name, callback) {
   return integrations().safelyRefresh(name, callback);
 }
 
-function refreshHermesIntegration(env = process.env) {
-  const currentRoot = currentRuntimePath(env);
-  const entry = managedIntegration("hermes", env) || legacyHermesIntegration(env);
-  if (!entry) return null;
-  const target = path.resolve(expandHome(entry.plugin_target));
-  const envPath = path.resolve(expandHome(entry.env_path));
-  const result = repairRuntimeSymlink(
-    "hermes",
-    target,
-    path.join(currentRoot, "hermes", "plugins", "agent_wallet"),
-    env,
-    { allowExternal: true },
-  );
-  result.env_repaired = repairHermesEnv(envPath, env);
-  result.restart_required = true;
-  if (result.ok) {
-    recordManagedIntegration(
-      "hermes",
-      { ...entry, plugin_target: target, env_path: envPath, restart_required: true },
-      env,
-    );
-  }
-  return result;
-}
-
-function refreshRegisteredCodexIntegration(env = process.env) {
-  const entry = managedIntegration("codex", env) || legacyCodexIntegration(env);
-  return entry ? refreshCodexIntegration(entry, env) : null;
-}
-
-function refreshRegisteredClaudeCodeIntegration(env = process.env) {
-  const entry = managedIntegration("claude-code", env) || legacyClaudeCodeIntegration(env);
-  return entry ? refreshClaudeCodeIntegration(entry, env) : null;
-}
-
 function repairInstalledEditorIntegrations(env = process.env) {
-  return integrations(env).refreshAll({
-    openclaw: () => repairOpenclawIntegration(env),
-    hermes: () => refreshHermesIntegration(env),
-    codex: () => refreshRegisteredCodexIntegration(env),
-    "claude-code": () => refreshRegisteredClaudeCodeIntegration(env),
-  });
+  return hostIntegrations(env).refreshAll();
 }
 
 const args = process.argv.slice(2);

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -600,6 +600,40 @@ function recoverInterruptedUpdate(env = process.env) {
   return { attempted: false, ok: false, reason: `unsupported update journal state: ${journal.state}` };
 }
 
+function updateRecoveryStatus(env = process.env) {
+  const journal = readUpdateJournal(env);
+  const state = journal?.state || null;
+  const currentPath = currentRuntimePath(env);
+  const currentTarget = readLinkOrNull(currentPath);
+  const currentResolves = Boolean(currentTarget && fs.existsSync(path.resolve(path.dirname(currentPath), currentTarget)));
+  let lockOwner = null;
+  try {
+    const owner = readJsonFile(path.join(updateLockPath(env), "owner.json"));
+    if (owner) {
+      lockOwner = {
+        pid: owner.pid,
+        hostname: owner.hostname,
+        started_at: owner.started_at,
+        active: owner.hostname === os.hostname() ? processIsRunning(Number(owner.pid)) : null,
+      };
+    }
+  } catch {
+    // Report an unreadable lock as present without trusting its contents.
+    if (fs.existsSync(updateLockPath(env))) lockOwner = { unreadable: true };
+  }
+  const needsRecovery = Boolean(
+    state && !["committed", "failed", "recovered"].includes(state),
+  );
+  return {
+    journal_schema_version: journal?.schema_version || null,
+    state,
+    journal_ok: state !== "corrupt",
+    needs_recovery: needsRecovery,
+    current_resolves: currentTarget ? currentResolves : null,
+    lock: lockOwner,
+  };
+}
+
 function writeReleaseState(runtimeRoot, state, details = {}) {
   writeJsonFile(path.join(runtimeRoot, ".agent-wallet-release.json"), {
     schema_version: 1,
@@ -1558,10 +1592,20 @@ function runDoctor(args = []) {
     fix: integrationSync.in_sync ? "" : "wallet update --yes",
   });
 
+  const recoveryStatus = updateRecoveryStatus(env);
+  checks.push({
+    name: "update_recovery_state",
+    ok: true,
+    ...recoveryStatus,
+    error: "",
+    fix: recoveryStatus.needs_recovery ? "wallet install --yes" : "",
+  });
+
   const ok = checks.every((c) => c.ok);
   console.log(
     JSON.stringify(
       {
+        schema_version: 1,
         ok,
         package_name: packageJson.name,
         package_version: packageVersion,
@@ -1581,6 +1625,7 @@ function runDoctor(args = []) {
 
 function runStatus(args = []) {
   const payload = {
+    schema_version: 1,
     ok: true,
     package_name: packageJson.name,
     package_version: packageVersion,
@@ -1594,6 +1639,7 @@ function runStatus(args = []) {
     update_available: computeUpdateAvailability(),
     runtime_in_sync: computeRuntimeInSync(),
     framework_integrations: integrationSyncStatus(),
+    update_recovery: updateRecoveryStatus(),
   };
   if (hasFlag(args, "--verbose")) {
     payload.verbose = true;

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -392,6 +392,27 @@ function updateJournalPath(env = process.env) {
   return path.join(resolveRuntimeBase(env), "update-journal.json");
 }
 
+function readUpdateJournal(env = process.env) {
+  try {
+    return readJsonFile(updateJournalPath(env));
+  } catch (error) {
+    return { schema_version: 1, state: "corrupt", error: error.message };
+  }
+}
+
+function runtimeOwnedPath(candidate, env = process.env) {
+  if (!candidate) return false;
+  const runtimeBase = path.resolve(resolveRuntimeBase(env));
+  const relative = path.relative(runtimeBase, path.resolve(candidate));
+  return relative !== "" && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function interruptedRuntimePath(version, env = process.env) {
+  return uniquePathWithSuffix(
+    path.join(resolveRuntimeBase(env), "releases", `.interrupted-${version || "unknown"}-${Date.now()}`),
+  );
+}
+
 function integrationRegistryPath(env = process.env) {
   return path.join(resolveRuntimeBase(env), "integrations.json");
 }
@@ -447,13 +468,65 @@ function integrationSyncStatus(env = process.env) {
 }
 
 function writeUpdateJournal(state, details = {}, env = process.env) {
-  writeJsonFile(updateJournalPath(env), {
-    schema_version: 1,
-    state,
-    version: packageVersion,
-    updated_at: new Date().toISOString(),
+  writeJsonFileAtomic(updateJournalPath(env), {
     ...details,
+    schema_version: 2,
+    state,
+    version: details.version || packageVersion,
+    updated_at: new Date().toISOString(),
   });
+}
+
+function recoverInterruptedUpdate(env = process.env) {
+  const journal = readUpdateJournal(env);
+  if (!journal || ["committed", "failed", "recovered"].includes(journal.state)) {
+    return { attempted: false, ok: true, reason: "no interrupted update" };
+  }
+  if (journal.state === "corrupt") {
+    return { attempted: false, ok: false, reason: "update journal is corrupt", error: journal.error };
+  }
+  const paths = [journal.staging_root, journal.release_root, journal.replaced_root].filter(Boolean);
+  if (paths.some((candidate) => !runtimeOwnedPath(candidate, env))) {
+    return { attempted: false, ok: false, reason: "update journal contains an unsafe path" };
+  }
+
+  if (journal.state === "committing") {
+    const releaseExists = Boolean(journal.release_root && fs.existsSync(journal.release_root));
+    const replacedExists = Boolean(journal.replaced_root && fs.existsSync(journal.replaced_root));
+    if (!releaseExists && replacedExists) {
+      fs.renameSync(journal.replaced_root, journal.release_root);
+      writeUpdateJournal(
+        "recovered",
+        { ...journal, state: undefined, action: "restored_replaced_release" },
+        env,
+      );
+      return { attempted: true, ok: true, action: "restored_replaced_release" };
+    }
+    if (releaseExists) {
+      writeUpdateJournal(
+        "recovered",
+        { ...journal, state: undefined, action: "release_already_present" },
+        env,
+      );
+      return { attempted: true, ok: true, action: "release_already_present" };
+    }
+    return { attempted: true, ok: false, reason: "interrupted commit has no recoverable release" };
+  }
+
+  if (["preparing", "verified"].includes(journal.state)) {
+    let quarantined = null;
+    if (journal.staging_root && fs.existsSync(journal.staging_root)) {
+      quarantined = interruptedRuntimePath(journal.version, env);
+      fs.renameSync(journal.staging_root, quarantined);
+    }
+    writeUpdateJournal(
+      "recovered",
+      { ...journal, state: undefined, action: "quarantined_incomplete_staging", quarantined_runtime: quarantined },
+      env,
+    );
+    return { attempted: true, ok: true, action: "quarantined_incomplete_staging", quarantined_runtime: quarantined };
+  }
+  return { attempted: false, ok: false, reason: `unsupported update journal state: ${journal.state}` };
 }
 
 function writeReleaseState(runtimeRoot, state, details = {}) {
@@ -477,14 +550,14 @@ function failStagingRuntime(stagingRoot, error) {
   return failedRoot;
 }
 
-function commitStagedRuntime(stagingRoot, releaseRoot) {
+function commitStagedRuntime(stagingRoot, releaseRoot, replacedRoot = null, env = process.env) {
   if (!stagingRoot) return null;
-  let replacedRoot = null;
   if (fs.existsSync(releaseRoot)) {
-    replacedRoot = uniquePathWithSuffix(
+    replacedRoot ||= uniquePathWithSuffix(
       path.join(path.dirname(releaseRoot), `${path.basename(releaseRoot)}-replaced`),
     );
     fs.renameSync(releaseRoot, replacedRoot);
+    if (env.AGENT_WALLET_TEST_EXIT_AFTER_RELEASE_RENAME === "1") process.exit(86);
   }
   try {
     fs.renameSync(stagingRoot, releaseRoot);
@@ -1522,6 +1595,13 @@ function runInstall(args, { commandName = "install" } = {}) {
   const previousPath = previousRuntimePath();
   const installerArgs = withoutCliOnlyArgs(args);
   const dryRun = hasFlag(args, "--dry-run");
+  const recovery = dryRun
+    ? { attempted: false, ok: true, reason: "dry run" }
+    : recoverInterruptedUpdate(process.env);
+  if (!recovery.ok) {
+    console.error(`Could not recover interrupted update: ${recovery.reason || recovery.error}`);
+    return 1;
+  }
   const stagingRoot = !explicitRuntimeRoot && !dryRun ? stagingRootFor(packageVersion) : null;
   const installRoot = stagingRoot || releaseRoot;
 
@@ -1542,7 +1622,17 @@ function runInstall(args, { commandName = "install" } = {}) {
   const { env, generated, bootKeySource } = installerEnv;
   if (stagingRoot) {
     env.OPENCLAW_INSTALL_FINAL_ROOT = releaseRoot;
-    writeUpdateJournal("preparing", { staging_root: stagingRoot, release_root: releaseRoot }, env);
+    writeUpdateJournal(
+      "preparing",
+      {
+        transaction_id: crypto.randomUUID(),
+        staging_root: stagingRoot,
+        release_root: releaseRoot,
+        current_target_before: readLinkOrNull(currentPath),
+        previous_target_before: readLinkOrNull(previousPath),
+      },
+      env,
+    );
   }
   const result = spawnSync("sh", [setupPath, ...installerArgs], {
     cwd: packageRoot,
@@ -1681,11 +1771,32 @@ function runInstall(args, { commandName = "install" } = {}) {
   writeReleaseState(installRoot, "verified", {
     verification_skipped: Boolean(verification.skipped),
   });
-  writeUpdateJournal("verified", { staging_root: stagingRoot, release_root: releaseRoot }, env);
+  writeUpdateJournal(
+    "verified",
+    { ...readUpdateJournal(env), staging_root: stagingRoot, release_root: releaseRoot },
+    env,
+  );
 
   let replacedRoot = null;
   try {
-    replacedRoot = commitStagedRuntime(stagingRoot, releaseRoot);
+    replacedRoot = fs.existsSync(releaseRoot)
+      ? uniquePathWithSuffix(
+          path.join(path.dirname(releaseRoot), `${path.basename(releaseRoot)}-replaced`),
+        )
+      : null;
+    writeUpdateJournal(
+      "committing",
+      {
+        ...readUpdateJournal(env),
+        staging_root: stagingRoot,
+        release_root: releaseRoot,
+        replaced_root: replacedRoot,
+        current_target_before: readLinkOrNull(currentPath),
+        previous_target_before: readLinkOrNull(previousPath),
+      },
+      env,
+    );
+    replacedRoot = commitStagedRuntime(stagingRoot, releaseRoot, replacedRoot, env);
   } catch (error) {
     const failedRoot = failStagingRuntime(stagingRoot, error.message);
     writeUpdateJournal("failed", { failed_runtime: failedRoot, error: error.message }, env);
@@ -1701,7 +1812,11 @@ function runInstall(args, { commandName = "install" } = {}) {
     switchSymlink(previousPath, previousTarget);
   }
   switchSymlink(currentPath, releaseRoot);
-  writeUpdateJournal("committed", { release_root: releaseRoot, previous_runtime: previousTarget }, env);
+  writeUpdateJournal(
+    "committed",
+    { ...readUpdateJournal(env), release_root: releaseRoot, previous_runtime: previousTarget },
+    env,
+  );
 
   recordManagedIntegration(
     "openclaw",
@@ -1739,6 +1854,7 @@ function runInstall(args, { commandName = "install" } = {}) {
         boot_key_source: bootKeySource,
         staged: Boolean(stagingRoot),
         release_state: "verified",
+        recovery,
         integration_refresh: integrationRefresh,
         global_cli_refresh: globalCliRefresh,
       },

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -392,6 +392,77 @@ function updateJournalPath(env = process.env) {
   return path.join(resolveRuntimeBase(env), "update-journal.json");
 }
 
+function updateLockPath(env = process.env) {
+  return path.join(resolveRuntimeBase(env), "update.lock");
+}
+
+function processIsRunning(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+function acquireUpdateLock(env = process.env, allowStaleRetry = true) {
+  const lockPath = updateLockPath(env);
+  const ownerPath = path.join(lockPath, "owner.json");
+  const token = crypto.randomUUID();
+  fs.mkdirSync(resolveRuntimeBase(env), { recursive: true });
+  try {
+    fs.mkdirSync(lockPath);
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+    let owner = null;
+    try {
+      owner = readJsonFile(ownerPath);
+    } catch {
+      // An unreadable lock is not safe to steal automatically.
+    }
+    const stale = owner?.hostname === os.hostname() && !processIsRunning(Number(owner.pid));
+    if (stale && allowStaleRetry) {
+      fs.rmSync(lockPath, { recursive: true, force: true });
+      return acquireUpdateLock(env, false);
+    }
+    return {
+      ok: false,
+      path: lockPath,
+      owner: owner ? { pid: owner.pid, hostname: owner.hostname, started_at: owner.started_at } : null,
+    };
+  }
+  try {
+    writeJsonFileAtomic(ownerPath, {
+      schema_version: 1,
+      pid: process.pid,
+      hostname: os.hostname(),
+      token,
+      started_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    fs.rmSync(lockPath, { recursive: true, force: true });
+    throw error;
+  }
+  return { ok: true, path: lockPath, owner_path: ownerPath, token };
+}
+
+function releaseUpdateLock(lock) {
+  if (!lock?.ok) return;
+  try {
+    const owner = readJsonFile(lock.owner_path);
+    if (owner?.token === lock.token) fs.rmSync(lock.path, { recursive: true, force: true });
+  } catch {
+    // Never remove a lock whose ownership can no longer be verified.
+  }
+}
+
+function holdUpdateLockForTest(env = process.env) {
+  const milliseconds = Number.parseInt(String(env.AGENT_WALLET_TEST_HOLD_LOCK_MS || ""), 10);
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
 function readUpdateJournal(env = process.env) {
   try {
     return readJsonFile(updateJournalPath(env));
@@ -1581,7 +1652,7 @@ function buildInstallerEnv(args) {
   return { env, generated, bootKeySource };
 }
 
-function runInstall(args, { commandName = "install" } = {}) {
+function runInstallUnlocked(args, { commandName = "install" } = {}) {
   if (!fs.existsSync(setupPath)) {
     console.error(`Missing bundled setup.sh at ${setupPath}`);
     return 1;
@@ -1863,6 +1934,34 @@ function runInstall(args, { commandName = "install" } = {}) {
     ),
   );
   return 0;
+}
+
+function runInstall(args, options = {}) {
+  if (hasFlag(args, "--dry-run")) return runInstallUnlocked(args, options);
+  const lock = acquireUpdateLock(process.env);
+  if (!lock.ok) {
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          category: "update_locked",
+          error: "Another wallet install or update is already running.",
+          lock_path: lock.path,
+          lock_owner: lock.owner,
+          fix: "Wait for the active update to finish, then retry.",
+        },
+        null,
+        2,
+      ),
+    );
+    return 1;
+  }
+  try {
+    holdUpdateLockForTest(process.env);
+    return runInstallUnlocked(args, options);
+  } finally {
+    releaseUpdateLock(lock);
+  }
 }
 
 function resolveUpdatePackageSpec(env = process.env) {

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -1902,7 +1902,10 @@ function runInstallUnlocked(args, { commandName = "install" } = {}) {
   );
 
   const integrationRefresh = repairInstalledEditorIntegrations(env);
-  const globalCliRefresh = refreshGlobalCliIfNeeded(env);
+  const globalCliRefresh = safelyRefreshIntegration(
+    "global-cli",
+    () => refreshGlobalCliIfNeeded(env),
+  );
 
   const pythonInfo = activePythonRuntimeInfo(env);
   const nodeInfo = activeNodeRuntimeInfo(env)
@@ -3111,43 +3114,69 @@ function refreshClaudeCodeIntegration(entry, env = process.env) {
   };
 }
 
-function repairInstalledEditorIntegrations(env = process.env) {
-  const results = [repairOpenclawIntegration(env)];
-  const currentRoot = currentRuntimePath(env);
-  const hermesEntry = managedIntegration("hermes", env) || legacyHermesIntegration(env);
-  if (hermesEntry) {
-    const hermesTarget = path.resolve(expandHome(hermesEntry.plugin_target));
-    const hermesEnvPath = path.resolve(expandHome(hermesEntry.env_path));
-    const result = repairRuntimeSymlink(
-      "hermes",
-      hermesTarget,
-      path.join(currentRoot, "hermes", "plugins", "agent_wallet"),
-      env,
-      { allowExternal: true },
-    );
-    result.env_repaired = repairHermesEnv(hermesEnvPath, env);
-    result.restart_required = true;
-    if (result.ok) {
-      recordManagedIntegration(
-        "hermes",
-        {
-          ...hermesEntry,
-          plugin_target: hermesTarget,
-          env_path: hermesEnvPath,
-          restart_required: true,
-        },
-        env,
-      );
-    }
-    results.push(result);
+function safelyRefreshIntegration(name, callback) {
+  try {
+    return callback();
+  } catch (error) {
+    const fix = name === "global-cli"
+      ? "Re-run: wallet update --yes"
+      : name === "openclaw"
+        ? "Re-run: wallet install --yes"
+        : `Re-run: wallet ${name} install --yes`;
+    return {
+      name,
+      attempted: true,
+      ok: false,
+      repaired: false,
+      error: error?.message || String(error),
+      restart_required: false,
+      fix,
+    };
   }
+}
 
-  const codexEntry = managedIntegration("codex", env) || legacyCodexIntegration(env);
-  if (codexEntry) results.push(refreshCodexIntegration(codexEntry, env));
+function refreshHermesIntegration(env = process.env) {
+  const currentRoot = currentRuntimePath(env);
+  const entry = managedIntegration("hermes", env) || legacyHermesIntegration(env);
+  if (!entry) return null;
+  const target = path.resolve(expandHome(entry.plugin_target));
+  const envPath = path.resolve(expandHome(entry.env_path));
+  const result = repairRuntimeSymlink(
+    "hermes",
+    target,
+    path.join(currentRoot, "hermes", "plugins", "agent_wallet"),
+    env,
+    { allowExternal: true },
+  );
+  result.env_repaired = repairHermesEnv(envPath, env);
+  result.restart_required = true;
+  if (result.ok) {
+    recordManagedIntegration(
+      "hermes",
+      { ...entry, plugin_target: target, env_path: envPath, restart_required: true },
+      env,
+    );
+  }
+  return result;
+}
 
-  const claudeEntry = managedIntegration("claude-code", env) || legacyClaudeCodeIntegration(env);
-  if (claudeEntry) results.push(refreshClaudeCodeIntegration(claudeEntry, env));
-  return results;
+function refreshRegisteredCodexIntegration(env = process.env) {
+  const entry = managedIntegration("codex", env) || legacyCodexIntegration(env);
+  return entry ? refreshCodexIntegration(entry, env) : null;
+}
+
+function refreshRegisteredClaudeCodeIntegration(env = process.env) {
+  const entry = managedIntegration("claude-code", env) || legacyClaudeCodeIntegration(env);
+  return entry ? refreshClaudeCodeIntegration(entry, env) : null;
+}
+
+function repairInstalledEditorIntegrations(env = process.env) {
+  return [
+    safelyRefreshIntegration("openclaw", () => repairOpenclawIntegration(env)),
+    safelyRefreshIntegration("hermes", () => refreshHermesIntegration(env)),
+    safelyRefreshIntegration("codex", () => refreshRegisteredCodexIntegration(env)),
+    safelyRefreshIntegration("claude-code", () => refreshRegisteredClaudeCodeIntegration(env)),
+  ].filter(Boolean);
 }
 
 const args = process.argv.slice(2);

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -1434,19 +1434,18 @@ function buildInstallerEnv(args) {
   const sealedKeysExist = fs.existsSync(sealedKeysPath);
   const dryRun = hasFlag(args, "--dry-run");
   let bootKeySource = env.AGENT_WALLET_BOOT_KEY ? "environment" : "none";
-  if (!env.AGENT_WALLET_BOOT_KEY) {
-    const runtimeResolution = readBootKeyFromRuntimeResolver(env);
-    const fallback = runtimeResolution.supported
-      ? {
-          key: runtimeResolution.key,
-          source: runtimeResolution.key ? "runtime_verified" : "runtime_rejected",
-        }
-      : resolveLegacyInstallerBootKey(env);
-    const existingBootKey = fallback.key;
-    bootKeySource = fallback.source;
-    if (existingBootKey) {
-      env.AGENT_WALLET_BOOT_KEY = existingBootKey;
+  const runtimeResolution = readBootKeyFromRuntimeResolver(env);
+  if (runtimeResolution.supported) {
+    bootKeySource = runtimeResolution.key ? "runtime_verified" : "runtime_rejected";
+    if (runtimeResolution.key) {
+      env.AGENT_WALLET_BOOT_KEY = runtimeResolution.key;
+    } else {
+      delete env.AGENT_WALLET_BOOT_KEY;
     }
+  } else if (!env.AGENT_WALLET_BOOT_KEY) {
+    const fallback = resolveLegacyInstallerBootKey(env);
+    bootKeySource = fallback.source;
+    if (fallback.key) env.AGENT_WALLET_BOOT_KEY = fallback.key;
   }
 
   const shouldGenerateSecrets =

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createBootKeyManager } from "./lib/boot-key.mjs";
+import { createIntegrationManager } from "./lib/integrations.mjs";
 import { createUpdateTransactionManager } from "./lib/update-transaction.mjs";
 
 const cliPath = fileURLToPath(import.meta.url);
@@ -417,58 +418,24 @@ function readUpdateJournal(env = process.env) {
   return updateTransactions(env).readJournal();
 }
 
-function integrationRegistryPath(env = process.env) {
-  return path.join(resolveRuntimeBase(env), "integrations.json");
-}
-
-function readIntegrationRegistry(env = process.env) {
-  const payload = readJsonFile(integrationRegistryPath(env));
-  if (!payload || payload.schema_version !== 1 || typeof payload.integrations !== "object") {
-    return { schema_version: 1, integrations: {} };
-  }
-  return payload;
+function integrations(env = process.env) {
+  return createIntegrationManager({
+    runtimeBase: resolveRuntimeBase(env),
+    packageVersion,
+    activeVersion: () => activeVersion(env),
+  });
 }
 
 function recordManagedIntegration(name, details = {}, env = process.env) {
-  const registry = readIntegrationRegistry(env);
-  registry.integrations[name] = {
-    ...details,
-    managed: true,
-    installed_version: packageVersion,
-    updated_at: new Date().toISOString(),
-  };
-  registry.updated_at = new Date().toISOString();
-  writeJsonFileAtomic(integrationRegistryPath(env), registry);
-  return registry.integrations[name];
+  return integrations(env).record(name, details);
 }
 
 function managedIntegration(name, env = process.env) {
-  const entry = readIntegrationRegistry(env).integrations[name];
-  return entry && entry.managed === true ? entry : null;
+  return integrations(env).managed(name);
 }
 
 function integrationSyncStatus(env = process.env) {
-  const active = activeVersion(env);
-  const registry = readIntegrationRegistry(env);
-  const integrations = Object.entries(registry.integrations)
-    .filter(([, entry]) => entry?.managed === true)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, entry]) => {
-      const versionInSync = active === null || entry.installed_version === active;
-      const registrationOk = entry.registration_ok !== false;
-      return {
-        name,
-        installed_version: entry.installed_version || null,
-        active_version: active,
-        in_sync: versionInSync && registrationOk,
-        registration_ok: registrationOk,
-        restart_required: Boolean(entry.restart_required),
-      };
-    });
-  return {
-    in_sync: integrations.every((entry) => entry.in_sync),
-    integrations,
-  };
+  return integrations(env).status();
 }
 
 function writeUpdateJournal(state, details = {}, env = process.env) {
@@ -2880,24 +2847,7 @@ function refreshClaudeCodeIntegration(entry, env = process.env) {
 }
 
 function safelyRefreshIntegration(name, callback) {
-  try {
-    return callback();
-  } catch (error) {
-    const fix = name === "global-cli"
-      ? "Re-run: wallet update --yes"
-      : name === "openclaw"
-        ? "Re-run: wallet install --yes"
-        : `Re-run: wallet ${name} install --yes`;
-    return {
-      name,
-      attempted: true,
-      ok: false,
-      repaired: false,
-      error: error?.message || String(error),
-      restart_required: false,
-      fix,
-    };
-  }
+  return integrations().safelyRefresh(name, callback);
 }
 
 function refreshHermesIntegration(env = process.env) {
@@ -2936,12 +2886,12 @@ function refreshRegisteredClaudeCodeIntegration(env = process.env) {
 }
 
 function repairInstalledEditorIntegrations(env = process.env) {
-  return [
-    safelyRefreshIntegration("openclaw", () => repairOpenclawIntegration(env)),
-    safelyRefreshIntegration("hermes", () => refreshHermesIntegration(env)),
-    safelyRefreshIntegration("codex", () => refreshRegisteredCodexIntegration(env)),
-    safelyRefreshIntegration("claude-code", () => refreshRegisteredClaudeCodeIntegration(env)),
-  ].filter(Boolean);
+  return integrations(env).refreshAll({
+    openclaw: () => repairOpenclawIntegration(env),
+    hermes: () => refreshHermesIntegration(env),
+    codex: () => refreshRegisteredCodexIntegration(env),
+    "claude-code": () => refreshRegisteredClaudeCodeIntegration(env),
+  });
 }
 
 const args = process.argv.slice(2);

--- a/bin/openclaw-agent-wallet.mjs
+++ b/bin/openclaw-agent-wallet.mjs
@@ -1231,6 +1231,39 @@ function verifyRuntime(releaseRoot, env = process.env) {
   };
 }
 
+function verifyBootKeyWithRuntime(releaseRoot, env = process.env) {
+  const sealedPath = path.join(resolveOpenclawHome(env), "sealed_keys.json");
+  if (!fs.existsSync(sealedPath)) return { ok: true, required: false };
+  const key = String(env.AGENT_WALLET_BOOT_KEY || "").trim();
+  if (!key) return { ok: false, required: true, error: "no verified boot key is available" };
+  const python =
+    env.AGENT_WALLET_PYTHON ||
+    env.OPENCLAW_AGENT_WALLET_PYTHON ||
+    resolveVenvPython(releaseRoot);
+  if (!python) {
+    if (String(env.AGENT_WALLET_VERIFY_DISABLE || "") === "1") {
+      return { ok: true, required: true, skipped: true };
+    }
+    return { ok: false, required: true, error: "staged Python runtime is unavailable" };
+  }
+  const result = spawnSync(
+    python,
+    [
+      "-c",
+      "from agent_wallet.sealed_keys import unseal_keys; import os; unseal_keys(os.environ['AGENT_WALLET_BOOT_KEY']); print('ok')",
+    ],
+    {
+      cwd: path.join(releaseRoot, "agent-wallet"),
+      encoding: "utf8",
+      timeout: positiveIntEnv("AGENT_WALLET_KEYSTORE_BRIDGE_TIMEOUT_MS", KEYSTORE_BRIDGE_TIMEOUT_MS, env),
+      env: { ...env, OPENCLAW_HOME: resolveOpenclawHome(env) },
+    },
+  );
+  return result.status === 0
+    ? { ok: true, required: true }
+    : { ok: false, required: true, error: "selected boot key does not unlock sealed wallet state" };
+}
+
 function resolveEditorServerChecks(env = process.env) {
   const checks = [];
   // Claude Code's launcher (run_mcp.sh) falls back to the runtime codex
@@ -1599,6 +1632,34 @@ function runInstall(args, { commandName = "install" } = {}) {
       "failed",
       { failed_runtime: failedRoot, error: verification.error, kept_version: previousVersion },
       env,
+    );
+    return 1;
+  }
+
+  const bootKeyVerification = verifyBootKeyWithRuntime(installRoot, env);
+  if (!bootKeyVerification.ok) {
+    const failedRoot = failStagingRuntime(stagingRoot, bootKeyVerification.error);
+    writeUpdateJournal(
+      "failed",
+      { failed_runtime: failedRoot, error: bootKeyVerification.error },
+      env,
+    );
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          command: commandName,
+          version: packageVersion,
+          category: "boot_key_rejected",
+          error: bootKeyVerification.error,
+          switched_current: false,
+          failed_runtime: failedRoot,
+          current_runtime_target: readLinkOrNull(currentPath),
+          fix: "Remove stale AGENT_WALLET_BOOT_KEY overrides and retry the update.",
+        },
+        null,
+        2,
+      ),
     );
     return 1;
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "agent-wallet/.env.example",
     "agent-wallet/AGENTS.md",
     "agent-wallet/README.md",
+    "agent-wallet/UPGRADE_COMPATIBILITY.md",
     "agent-wallet/openclaw.plugin.json",
     "agent-wallet/pyproject.toml",
     ".openclaw/AGENTS.md",


### PR DESCRIPTION
## Summary\n- verify explicit boot-key candidates against sealed wallet state before committing a runtime\n- recover interrupted staged updates safely and serialize concurrent installer runs\n- isolate and track managed framework integrations across Codex, Claude Code, OpenClaw, and Hermes\n- prevent cross-home legacy adoption and recover corrupt integration registries without losing forensic data\n- extract boot-key, update-transaction, and integration lifecycle code into focused modules\n\n## Compatibility and safety\n- preserves legacy upgrade paths and rollback-compatible storage\n- leaves unmanaged and external integrations untouched\n- keeps framework refresh failures non-blocking\n- quarantines failed staging directories and corrupt registry data rather than deleting them\n\n## Verification\n- npm run check\n- npm run check:release-version\n- npm run check:openclaw-plugins\n- node --test agent-wallet/tests/update_transaction.test.mjs\n- python3 agent-wallet/tests/smoke_npm_installer.py\n- python3 agent-wallet/tests/e2e_install_upgrade.py\n- python3 agent-wallet/tests/e2e_install_new_user.py\n- boot-key, integration refresh, cross-home, corrupt-registry, lock, and interrupted-update smoke tests\n- npm pack --dry-run