### PR TITLE
docs: add Solana x402 preflight recipe

### DIFF
--- a/docs/src/content/docs/wallet/x402.mdx
+++ b/docs/src/content/docs/wallet/x402.mdx
@@ -31,6 +31,50 @@ The wallet can now help with:
 - making an unpaid request first and parsing `402 Payment Required`
 - preparing or executing the exact payment-bound request through the active wallet backend
 
+## Solana commerce preflight recipe
+
+For an agent that is about to submit a Solana payment or transaction, use a
+small paid preflight before the higher-value action. Utilia is indexed in both
+CDP Bazaar and Agentic Market and exposes a live priority-fee feed for
+`$0.002` per call.
+
+First preview the exact request without spending:
+
+```text
+x402_preview_request({
+  "url": "https://api.utilia.ink/v1/fees/priority"
+})
+```
+
+After reviewing the network, asset, amount, and destination in the preview,
+execute the same payment-bound request:
+
+```text
+x402_pay_request({
+  "url": "https://api.utilia.ink/v1/fees/priority",
+  "purpose": "Choose a current Solana compute-unit price before submitting the transaction"
+})
+```
+
+Use the returned `mediumMicroLamports`, `highMicroLamports`, or
+`urgentMicroLamports` value according to the transaction's urgency. The
+response is timestamped, so fetch it immediately before building or submitting
+the transaction instead of caching it as a static default.
+
+If the downstream transaction lands with an error, pass its confirmed
+signature to the `$0.004` diagnosis route. It returns balance deltas, logs,
+compute use, a failure class, and a retry-aware next action:
+
+```text
+x402_preview_request({
+  "url": "https://api.utilia.ink/v1/transaction/CONFIRMED_SIGNATURE"
+})
+```
+
+This keeps the full workflow inside AgentLayer's normal
+discovery → preview → approval → execution model. The examples use Solana
+routes; equivalent Base USDC aliases are available under `/base/v1/...`.
+
 ## Current execution model
 
 This milestone is not symmetric across chains.


### PR DESCRIPTION
## What changed

- adds a concrete Solana commerce preflight recipe to the x402 wallet docs
- shows the existing `x402_preview_request` → `x402_pay_request` flow against a live, indexed provider
- documents a paid transaction-diagnosis fallback for failed Solana settlements

## Why

AgentLayer already exposes the generic x402 buyer tools, but the docs stop before
showing how to compose them into a real Solana transaction workflow. Utilia is
indexed in both CDP Bazaar and Agentic Market, so it provides a reproducible
example without adding a curated-provider code path.

The recipe keeps AgentLayer's safety model intact: preview the exact request,
review the payment requirement, and execute the same payment-bound request
through the active wallet.

## Validation

- `npm run build` in `docs/`
- `git diff --check`
- live unpaid request to `https://api.utilia.ink/v1/fees/priority` returned HTTP
  402 with x402 v2 `exact`, Solana mainnet, USDC amount `2000`, and the documented
  `$0.002` price
- CDP Bazaar search and Agentic Market search both return `api.utilia.ink`

No wallet funds were spent during validation.
